### PR TITLE
feat(aspnetcore): add kernel exception mapping, correlation warnings,…

### DIFF
--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Auth/RestAuthorizationResultHandler.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Auth/RestAuthorizationResultHandler.cs
@@ -77,10 +77,14 @@ internal sealed class RestAuthorizationResultHandler : IAuthorizationMiddlewareR
         string correlationId = RestAuthExtensions.GetCorrelationId(context);
         string? traceId = Activity.Current?.Id;
 
-        // Use IAuthenticatedIdentityAccessor if available to provide more context
+        // Use IAuthenticatedIdentityAccessor if available; fall back to HttpContext.User
         IAuthenticatedIdentityAccessor? identityAccessor = context.RequestServices.GetService(typeof(IAuthenticatedIdentityAccessor)) as IAuthenticatedIdentityAccessor;
 
-        string message = identityAccessor?.IsAuthenticated == true
+        bool isAuthenticated = identityAccessor?.IsAuthenticated
+            ?? context.User?.Identity?.IsAuthenticated
+            ?? false;
+
+        string message = isAuthenticated
             ? "You do not have permission to access this resource."
             : "Authentication is required.";
 

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to HoneyDrunk.Web.Rest.AspNetCore will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-02-14
+
+### Changed
+
+#### Dependencies
+- Bumped `HoneyDrunk.Kernel.Abstractions` from 0.3.0 to 0.4.0
+- Bumped `HoneyDrunk.Transport` from 0.3.0 to 0.4.0
+- Bumped `HoneyDrunk.Auth.AspNetCore` from 0.1.0 to 0.2.0
+
+### Added
+
+#### Exception Mapping
+- `JsonException` maps to 400 Bad Request (`BAD_REQUEST`) — malformed JSON bodies
+- `BadHttpRequestException` maps to 400 Bad Request (`BAD_REQUEST`) — malformed requests
+- Kernel `ValidationException` maps to 400 Bad Request (`BAD_REQUEST`)
+- Kernel `NotFoundException` maps to 404 Not Found (`NOT_FOUND`)
+- Kernel `ConcurrencyException` maps to 409 Conflict (`CONFLICT`)
+- Kernel `SecurityException` maps to 403 Forbidden (`FORBIDDEN`)
+- Kernel `DependencyFailureException` maps to 503 Service Unavailable (`SERVICE_UNAVAILABLE`)
+- All Kernel exception messages use safe static strings — no internal message leakage
+
+#### Middleware
+- `ExceptionMappingMiddleware` now guards against `Response.HasStarted` — exception is still logged but no response is attempted when headers have already been sent
+- `CorrelationMiddleware` now accepts `ILogger<CorrelationMiddleware>` and logs a warning when both Kernel and header correlation IDs are present but differ (includes header value, kernel value, HTTP method, and request path)
+
+#### Auth
+- `RestAuthorizationResultHandler.WriteForbiddenResponseAsync` falls back to `HttpContext.User.Identity.IsAuthenticated` when `IAuthenticatedIdentityAccessor` is not registered
+
+### Notes
+- Kernel typed exceptions are matched before BCL fallbacks in the switch expression to ensure specificity
+- The HasStarted guard prevents `InvalidOperationException` from being thrown when middleware runs after streaming has begun
+- Correlation mismatch warning helps diagnose middleware ordering issues in multi-context environments
+
 ## [0.1.0] - 2026-01-10
 
 ### Added
@@ -97,4 +130,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kernel/Auth/Transport integrations are optional - middleware gracefully degrades when not registered
 - Auth failure shaping uses `IAuthorizationMiddlewareResultHandler` for scheme-agnostic 401/403 handling
 
+[0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.AspNetCore</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>ASP.NET Core integration for HoneyDrunk REST conventions. Provides middleware for correlation propagation, exception mapping, and request logging. Includes MVC filters for model validation, minimal API endpoint conventions, and JSON serialization defaults. Ensures consistent API responses across all services.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release with CorrelationMiddleware, ExceptionMappingMiddleware, RequestLoggingScopeMiddleware, ModelStateValidationFilter, ApiConventions, RestEndpointConventions, JsonOptionsDefaults, and ICorrelationIdAccessor.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.0: Added JsonException/BadHttpRequestException to 400 mapping, Kernel typed exception mappings (ValidationException, NotFoundException, ConcurrencyException, SecurityException, DependencyFailureException), HasStarted guard in ExceptionMappingMiddleware, correlation mismatch warning logging, and auth HttpContext.User fallback. Bumped Kernel.Abstractions to 0.4.0, Transport to 0.4.0, Auth.AspNetCore to 0.2.0.</PackageReleaseNotes>
     <PackageTags>rest;api;aspnetcore;middleware;correlation;exception;validation;filter;json;conventions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -29,13 +29,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.1.0" />
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.3.0" />
+    <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.2.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Transport" Version="0.3.0" />
+    <PackageReference Include="HoneyDrunk.Transport" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/ExceptionMappingMiddleware.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/ExceptionMappingMiddleware.cs
@@ -73,6 +73,11 @@ public sealed class ExceptionMappingMiddleware(
             correlationId,
             traceId);
 
+        if (context.Response.HasStarted)
+        {
+            return;
+        }
+
         ExceptionMappingResult mapping = ExceptionToApiErrorMapper.Map(exception);
 
         bool includeDetails = _options.IncludeExceptionDetails && environment.IsDevelopment();

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/AuthShapingCanary.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/AuthShapingCanary.cs
@@ -1,0 +1,120 @@
+using HoneyDrunk.Web.Rest.Abstractions.Errors;
+using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Invariant 3: Auth shaping — 401 vs 403 message correctness,
+/// including fallback when IAuthenticatedIdentityAccessor is not registered.
+/// </summary>
+public sealed class AuthShapingCanary : IDisposable
+{
+    private readonly CanaryHostFactory _factory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthShapingCanary"/> class.
+    /// </summary>
+    public AuthShapingCanary()
+    {
+        _factory = new CanaryHostFactory
+        {
+            // Auth is configured WITHOUT IAuthenticatedIdentityAccessor,
+            // forcing RestAuthorizationResultHandler to fall back to HttpContext.User.Identity.IsAuthenticated
+            UseAuthWithoutIdentityAccessor = true,
+        };
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _factory.Dispose();
+
+    /// <summary>
+    /// No auth token → 401 with "Authentication is required." message.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task NoToken_Returns401_WithAuthRequiredMessage()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/auth/protected", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        string body = await response.Content.ReadAsStringAsync();
+        ApiErrorResponse? error = JsonSerializer.Deserialize<ApiErrorResponse>(body, JsonOptionsDefaults.SerializerOptions);
+
+        error.ShouldNotBeNull();
+        error.Error.ShouldNotBeNull();
+        error.Error.Code.ShouldBe(ApiErrorCode.Unauthorized);
+        error.Error.Message.ShouldContain("Authentication is required");
+    }
+
+    /// <summary>
+    /// Authenticated user lacking required role → 403 with permission-denied message.
+    /// IAuthenticatedIdentityAccessor is NOT registered — handler falls back to HttpContext.User.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task AuthenticatedButUnauthorized_Returns403_WithPermissionMessage()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        // Send auth header that authenticates the user with no roles (not Admin)
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/canary/auth/protected", UriKind.Relative));
+        request.Headers.Add("X-Canary-Auth", "authenticated");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+
+        string body = await response.Content.ReadAsStringAsync();
+        ApiErrorResponse? error = JsonSerializer.Deserialize<ApiErrorResponse>(body, JsonOptionsDefaults.SerializerOptions);
+
+        error.ShouldNotBeNull();
+        error.Error.ShouldNotBeNull();
+        error.Error.Code.ShouldBe(ApiErrorCode.Forbidden);
+
+        // Critical: with HttpContext.User fallback, authenticated user must get permission message, not auth-required
+        error.Error.Message.ShouldContain("permission");
+        error.Error.Message.ShouldNotContain("Authentication is required");
+    }
+
+    /// <summary>
+    /// Authenticated user WITH required role → 200 (control case).
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task AuthenticatedWithRole_Returns200()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/canary/auth/protected", UriKind.Relative));
+        request.Headers.Add("X-Canary-Auth", "admin");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    /// <summary>
+    /// Auth-shaped responses include correlation ID in the response body.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task AuthError_IncludesCorrelationId()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/auth/protected", UriKind.Relative));
+
+        string body = await response.Content.ReadAsStringAsync();
+        ApiErrorResponse? error = JsonSerializer.Deserialize<ApiErrorResponse>(body, JsonOptionsDefaults.SerializerOptions);
+
+        error.ShouldNotBeNull();
+
+        // Correlation ID may be empty if correlation middleware ran before auth, or generated
+        // The key invariant is that the field is present and the envelope is shaped correctly
+        error.CorrelationId.ShouldNotBeNull();
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryAuthHandler.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryAuthHandler.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+#pragma warning disable CA1812 // Instantiated via AddScheme<> reflection
+
+/// <summary>
+/// A test authentication handler that authenticates based on a custom header.
+/// Send <c>X-Canary-Auth: authenticated</c> to be authenticated with no roles.
+/// Send <c>X-Canary-Auth: admin</c> to be authenticated with the Admin role.
+/// Omit the header to be unauthenticated.
+/// </summary>
+internal sealed class CanaryAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    /// <inheritdoc/>
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("X-Canary-Auth", out Microsoft.Extensions.Primitives.StringValues authHeader)
+            || string.IsNullOrWhiteSpace(authHeader.ToString()))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        string authValue = authHeader.ToString();
+
+        List<Claim> claims =
+        [
+            new Claim(ClaimTypes.Name, "canary-user"),
+        ];
+
+        if (string.Equals(authValue, "admin", StringComparison.OrdinalIgnoreCase))
+        {
+            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
+        }
+
+        ClaimsIdentity identity = new(claims, "CanaryScheme");
+        ClaimsPrincipal principal = new(identity);
+        AuthenticationTicket ticket = new(principal, "CanaryScheme");
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryEndpoints.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryEndpoints.cs
@@ -1,0 +1,92 @@
+using HoneyDrunk.Kernel.Abstractions.Errors;
+using HoneyDrunk.Web.Rest.Abstractions.Results;
+using HoneyDrunk.Web.Rest.AspNetCore.Context;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Minimal endpoints that trigger specific edge behaviors for canary verification.
+/// </summary>
+internal static class CanaryEndpoints
+{
+    /// <summary>
+    /// Maps all canary endpoints to the endpoint route builder.
+    /// </summary>
+    public static IEndpointRouteBuilder MapCanaryEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        // Invariant 1: Malformed JSON
+        endpoints.MapPost("/canary/json-body", (Delegate)JsonBodyHandler);
+
+        // Invariant 2: Kernel typed exceptions
+        endpoints.MapGet("/canary/kernel/not-found", KernelNotFoundHandler);
+        endpoints.MapGet("/canary/kernel/validation", KernelValidationHandler);
+        endpoints.MapGet("/canary/kernel/concurrency", KernelConcurrencyHandler);
+        endpoints.MapGet("/canary/kernel/dependency-failure", KernelDependencyFailureHandler);
+        endpoints.MapGet("/canary/kernel/security", KernelSecurityHandler);
+
+        // Invariant 4: Correlation round-trip
+        endpoints.MapGet("/canary/correlation", CorrelationHandler);
+
+        // Invariant 5: Response.HasStarted safety
+        endpoints.MapGet("/canary/response-started", ResponseStartedHandler);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> JsonBodyHandler(HttpContext context)
+    {
+        // Manually read and parse the body so that JsonException flows through
+        // ExceptionMappingMiddleware rather than being swallowed by minimal API binding.
+        using StreamReader reader = new(context.Request.Body);
+        string raw = await reader.ReadToEndAsync().ConfigureAwait(false);
+        _ = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
+        return Results.Ok(ApiResult.Success());
+    }
+
+    private static IResult KernelNotFoundHandler()
+    {
+        throw new NotFoundException("Canary: resource was not found.");
+    }
+
+    private static IResult KernelValidationHandler()
+    {
+        throw new ValidationException("Canary: validation failed.");
+    }
+
+    private static IResult KernelConcurrencyHandler()
+    {
+        throw new ConcurrencyException("Canary: concurrency conflict.");
+    }
+
+    private static IResult KernelDependencyFailureHandler()
+    {
+        throw new DependencyFailureException("Canary: downstream dependency failed.");
+    }
+
+    private static IResult KernelSecurityHandler()
+    {
+        throw new Kernel.Abstractions.Errors.SecurityException("Canary: access denied.");
+    }
+
+    private static IResult CorrelationHandler(ICorrelationIdAccessor correlationAccessor)
+    {
+        return Results.Ok(new { correlationAccessor.CorrelationId });
+    }
+
+    private static async Task ResponseStartedHandler(HttpContext context)
+    {
+        // Begin writing the response body — this sets Response.HasStarted = true
+        context.Response.StatusCode = 200;
+        context.Response.ContentType = "text/plain";
+        await context.Response.WriteAsync("partial response content").ConfigureAwait(false);
+        await context.Response.Body.FlushAsync().ConfigureAwait(false);
+
+        // Now throw — ExceptionMappingMiddleware must not attempt to write again
+#pragma warning disable CA2201 // Exception type System.Exception is not sufficiently specific
+        throw new Exception("Canary: exception after response started.");
+#pragma warning restore CA2201
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
@@ -1,0 +1,133 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Extensions;
+using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Creates an in-process test server for canary verification.
+/// Supports optional registration of a fake <see cref="IOperationContextAccessor"/>
+/// to simulate Kernel correlation presence without creating Kernel context objects.
+/// </summary>
+internal sealed class CanaryHostFactory : IDisposable
+{
+    private IHost? _host;
+    private HttpClient? _client;
+
+    /// <summary>
+    /// Gets or sets an optional fake <see cref="IOperationContextAccessor"/> to register.
+    /// Set before calling <see cref="CreateClient"/>.
+    /// </summary>
+    public IOperationContextAccessor? OperationContextAccessor { get; set; }
+
+    /// <summary>
+    /// Gets captured log entries from the most recent host.
+    /// </summary>
+    public CapturingLoggerProvider LogCapture { get; } = new();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to register auth services with a protected
+    /// endpoint but NO <c>IAuthenticatedIdentityAccessor</c>, forcing the fallback to HttpContext.User.
+    /// </summary>
+    public bool UseAuthWithoutIdentityAccessor { get; set; }
+
+    /// <summary>
+    /// Creates an HTTP client backed by the in-process test server.
+    /// </summary>
+    public HttpClient CreateClient()
+    {
+        if (_client is not null)
+        {
+            return _client;
+        }
+
+        _host = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddRest(options =>
+                    {
+                        options.IncludeExceptionDetails = false;
+                        options.EnableRequestLoggingScope = true;
+                        options.EnableExceptionMapping = true;
+                        options.EnableAuthFailureShaping = true;
+                    });
+
+                    services.Configure<JsonOptions>(options =>
+                    {
+                        JsonOptionsDefaults.Configure(options.SerializerOptions);
+                    });
+
+                    services.AddRouting();
+
+                    // Register fake operation context accessor if provided
+                    if (OperationContextAccessor is not null)
+                    {
+                        services.AddSingleton(OperationContextAccessor);
+                    }
+
+                    // Auth setup
+                    if (UseAuthWithoutIdentityAccessor)
+                    {
+                        services.AddAuthentication("CanaryScheme")
+                            .AddScheme<
+                                Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions,
+                                CanaryAuthHandler>("CanaryScheme", _ => { });
+
+                        services.AddAuthorizationBuilder()
+                            .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));
+                    }
+                });
+
+                webBuilder.Configure(app =>
+                {
+                    app.UseRest();
+                    app.UseRouting();
+
+                    if (UseAuthWithoutIdentityAccessor)
+                    {
+                        app.UseAuthentication();
+                        app.UseAuthorization();
+                    }
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapCanaryEndpoints();
+
+                        if (UseAuthWithoutIdentityAccessor)
+                        {
+                            endpoints.MapGet("/canary/auth/protected", () => Results.Ok("ok"))
+                                .RequireAuthorization("AdminOnly");
+                        }
+                    });
+                });
+            })
+            .ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddProvider(LogCapture);
+                logging.SetMinimumLevel(LogLevel.Trace);
+            })
+            .Start();
+
+        _client = _host.GetTestClient();
+        return _client;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _client?.Dispose();
+        _host?.Dispose();
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CapturedLogEntry.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CapturedLogEntry.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// A captured log entry for assertion.
+/// </summary>
+internal sealed class CapturedLogEntry
+{
+    /// <summary>Gets or sets the logger category.</summary>
+    public required string Category { get; set; }
+
+    /// <summary>Gets or sets the log level.</summary>
+    public required LogLevel LogLevel { get; set; }
+
+    /// <summary>Gets or sets the formatted message.</summary>
+    public required string Message { get; set; }
+
+    /// <summary>Gets or sets the exception, if any.</summary>
+    public Exception? Exception { get; set; }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CapturingLoggerProvider.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CapturingLoggerProvider.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// A logger provider that captures log entries for canary assertions.
+/// </summary>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    /// <summary>
+    /// Gets the captured log entries.
+    /// </summary>
+    public ConcurrentBag<CapturedLogEntry> Entries { get; } = [];
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new CapturingLogger(categoryName, this);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // No resources to dispose.
+    }
+
+    private sealed class CapturingLogger(string category, CapturingLoggerProvider provider) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            provider.Entries.Add(new CapturedLogEntry
+            {
+                Category = category,
+                LogLevel = logLevel,
+                Message = formatter(state, exception),
+                Exception = exception,
+            });
+        }
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CorrelationCanary.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CorrelationCanary.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Invariant 4: Correlation mismatch warning visibility and round-trip behavior.
+/// </summary>
+public sealed class CorrelationCanary : IDisposable
+{
+    /// <summary>
+    /// Header correlation round-trips into response header when no Kernel context is present.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task HeaderCorrelation_RoundTripsToResponseHeader()
+    {
+        using CanaryHostFactory factory = new();
+        HttpClient client = factory.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/canary/correlation", UriKind.Relative));
+        request.Headers.Add("X-Correlation-Id", "header-123");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Verify response header echoes the correlation
+        response.Headers.TryGetValues("X-Correlation-Id", out System.Collections.Generic.IEnumerable<string>? values).ShouldBeTrue();
+        values!.ShouldContain("header-123");
+
+        // Verify response body has the same correlation
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("correlationId").GetString().ShouldBe("header-123");
+    }
+
+    /// <summary>
+    /// When Kernel operation context has a different correlation ID than the header,
+    /// Kernel wins and a warning is logged about the mismatch.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task KernelCorrelationOverridesHeader_AndWarningIsLogged()
+    {
+        FakeOperationContextAccessor fakeAccessor = new()
+        {
+            Current = new StubOperationContext("kernel-456"),
+        };
+
+        using CanaryHostFactory factory = new()
+        {
+            OperationContextAccessor = fakeAccessor,
+        };
+
+        HttpClient client = factory.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/canary/correlation", UriKind.Relative));
+        request.Headers.Add("X-Correlation-Id", "header-123");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Kernel correlation should win
+        response.Headers.TryGetValues("X-Correlation-Id", out System.Collections.Generic.IEnumerable<string>? values).ShouldBeTrue();
+        values!.ShouldContain("kernel-456");
+
+        // Response body should have kernel correlation
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("correlationId").GetString().ShouldBe("kernel-456");
+
+        // A warning should have been logged about the mismatch
+        factory.LogCapture.Entries.ShouldContain(e =>
+            e.LogLevel == LogLevel.Warning
+            && e.Message.Contains("header-123")
+            && e.Message.Contains("kernel-456")
+            && e.Message.Contains("mismatch", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// When Kernel and header correlation are the same, no mismatch warning is logged.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task MatchingCorrelation_NoWarningLogged()
+    {
+        FakeOperationContextAccessor fakeAccessor = new()
+        {
+            Current = new StubOperationContext("same-id"),
+        };
+
+        using CanaryHostFactory factory = new()
+        {
+            OperationContextAccessor = fakeAccessor,
+        };
+
+        HttpClient client = factory.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/canary/correlation", UriKind.Relative));
+        request.Headers.Add("X-Correlation-Id", "same-id");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // No mismatch warning should exist
+        factory.LogCapture.Entries.ShouldNotContain(e =>
+            e.LogLevel == LogLevel.Warning
+            && e.Message.Contains("mismatch", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // Individual factories are disposed inline.
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/FakeOperationContextAccessor.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/FakeOperationContextAccessor.cs
@@ -1,0 +1,14 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// A fake <see cref="IOperationContextAccessor"/> that returns a mock operation context
+/// with a configurable correlation ID. Does NOT create a real Kernel context —
+/// uses interface-only mocking to satisfy the DI contract.
+/// </summary>
+internal sealed class FakeOperationContextAccessor : IOperationContextAccessor
+{
+    /// <inheritdoc/>
+    public IOperationContext? Current { get; set; }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HoneyDrunk.Web.Rest.Abstractions\HoneyDrunk.Web.Rest.Abstractions.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Web.Rest.AspNetCore\HoneyDrunk.Web.Rest.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101" />
+  </ItemGroup>
+
+</Project>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/KernelExceptionMappingCanary.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/KernelExceptionMappingCanary.cs
@@ -1,0 +1,149 @@
+using HoneyDrunk.Web.Rest.Abstractions.Errors;
+using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Invariant 2: Kernel typed exceptions map to correct HTTP status codes.
+/// </summary>
+public sealed class KernelExceptionMappingCanary : IDisposable
+{
+    private readonly CanaryHostFactory _factory = new();
+
+    /// <inheritdoc/>
+    public void Dispose() => _factory.Dispose();
+
+    /// <summary>
+    /// Kernel NotFoundException maps to 404 Not Found.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task KernelNotFoundException_Returns404()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/kernel/not-found", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+        error.Error!.Code.ShouldBe(ApiErrorCode.NotFound);
+    }
+
+    /// <summary>
+    /// Kernel ValidationException maps to 400 Bad Request.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task KernelValidationException_Returns400()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/kernel/validation", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+        error.Error!.Code.ShouldBe(ApiErrorCode.BadRequest);
+    }
+
+    /// <summary>
+    /// Kernel ConcurrencyException maps to 409 Conflict.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task KernelConcurrencyException_Returns409()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/kernel/concurrency", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+        error.Error!.Code.ShouldBe(ApiErrorCode.Conflict);
+    }
+
+    /// <summary>
+    /// Kernel DependencyFailureException maps to 503 Service Unavailable.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task KernelDependencyFailureException_Returns503()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/kernel/dependency-failure", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+        error.Error!.Code.ShouldBe(ApiErrorCode.ServiceUnavailable);
+    }
+
+    /// <summary>
+    /// Kernel SecurityException maps to 403 Forbidden.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task KernelSecurityException_Returns403()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/kernel/security", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+        error.Error!.Code.ShouldBe(ApiErrorCode.Forbidden);
+    }
+
+    /// <summary>
+    /// Every Kernel exception response includes a non-null error message (no leaky internals).
+    /// </summary>
+    /// <param name="path">The endpoint path that triggers the Kernel exception.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData("/canary/kernel/not-found")]
+    [InlineData("/canary/kernel/validation")]
+    [InlineData("/canary/kernel/concurrency")]
+    [InlineData("/canary/kernel/dependency-failure")]
+    [InlineData("/canary/kernel/security")]
+    public async Task KernelExceptions_HaveNonEmptyMessage(string path)
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri(path, UriKind.Relative));
+
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+        error.Error!.Message.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>
+    /// No Kernel exception leaks internal exception details in the response.
+    /// </summary>
+    /// <param name="path">The endpoint path that triggers the Kernel exception.</param>
+    /// <param name="internalFragment">A fragment from the internal exception message that must not appear.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData("/canary/kernel/not-found", "Canary:")]
+    [InlineData("/canary/kernel/validation", "Canary:")]
+    [InlineData("/canary/kernel/concurrency", "Canary:")]
+    [InlineData("/canary/kernel/dependency-failure", "Canary:")]
+    [InlineData("/canary/kernel/security", "Canary:")]
+    public async Task KernelExceptions_DoNotLeakInternalMessage(string path, string internalFragment)
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri(path, UriKind.Relative));
+
+        ApiErrorResponse? error = await DeserializeError(response);
+        error.ShouldNotBeNull();
+
+        // The safe static message should NOT contain the internal exception message fragment
+        error.Error!.Message.ShouldNotContain(internalFragment);
+    }
+
+    private static async Task<ApiErrorResponse?> DeserializeError(HttpResponseMessage response)
+    {
+        string body = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<ApiErrorResponse>(body, JsonOptionsDefaults.SerializerOptions);
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/MalformedJsonCanary.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/MalformedJsonCanary.cs
@@ -1,0 +1,56 @@
+using HoneyDrunk.Web.Rest.Abstractions.Errors;
+using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
+using Shouldly;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Invariant 1: Malformed JSON is 400 with ApiErrorResponse, not 500.
+/// </summary>
+public sealed class MalformedJsonCanary : IDisposable
+{
+    private readonly CanaryHostFactory _factory = new();
+
+    /// <summary>
+    /// Malformed JSON body returns 400 Bad Request with standard ApiErrorResponse envelope.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task MalformedJson_Returns400_WithApiErrorResponse()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        using StringContent content = new("{ this is not valid json }", Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await client.PostAsync(new Uri("/canary/json-body", UriKind.Relative), content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        string body = await response.Content.ReadAsStringAsync();
+        ApiErrorResponse? error = JsonSerializer.Deserialize<ApiErrorResponse>(body, JsonOptionsDefaults.SerializerOptions);
+
+        error.ShouldNotBeNull();
+        error.Error.ShouldNotBeNull();
+        error.Error.Code.ShouldBe(ApiErrorCode.BadRequest);
+    }
+
+    /// <summary>
+    /// Valid JSON body returns 200 OK (control case).
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidJson_Returns200()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        using StringContent content = new("{}", Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await client.PostAsync(new Uri("/canary/json-body", UriKind.Relative), content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _factory.Dispose();
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/ResponseStartedCanary.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/ResponseStartedCanary.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using System.Net;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// Invariant 5: Response.HasStarted safety — ExceptionMappingMiddleware must not
+/// throw a secondary exception when attempting to write after the response has started.
+/// </summary>
+public sealed class ResponseStartedCanary : IDisposable
+{
+    private readonly CanaryHostFactory _factory = new();
+
+    /// <summary>
+    /// An endpoint that throws after writing partial response content does not crash the server.
+    /// The original exception is logged, but no secondary exception occurs from the middleware.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExceptionAfterResponseStarted_DoesNotCrash()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        // This should not throw — the server should handle it gracefully
+        HttpResponseMessage response = await client.GetAsync(new Uri("/canary/response-started", UriKind.Relative));
+
+        // The response started with 200 before the exception was thrown,
+        // so the status code should be 200 (cannot be changed after HasStarted)
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The body should contain the partial content that was written before the throw
+        string body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("partial response content");
+    }
+
+    /// <summary>
+    /// The original exception is still logged even though the response cannot be shaped.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExceptionAfterResponseStarted_ExceptionIsStillLogged()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        await client.GetAsync(new Uri("/canary/response-started", UriKind.Relative));
+
+        // The exception should have been logged at Error level
+        _factory.LogCapture.Entries.ShouldContain(e =>
+            e.LogLevel == LogLevel.Error
+            && e.Message.Contains("unhandled exception", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _factory.Dispose();
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubGridContext.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubGridContext.cs
@@ -1,0 +1,49 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// A minimal <see cref="IGridContext"/> stub that returns empty/default values.
+/// Used by <see cref="StubOperationContext"/> to satisfy RequestLoggingScopeMiddleware
+/// which accesses GridContext properties for telemetry enrichment.
+/// </summary>
+internal sealed class StubGridContext : IGridContext
+{
+    /// <inheritdoc/>
+    public bool IsInitialized => true;
+
+    /// <inheritdoc/>
+    public string CorrelationId => string.Empty;
+
+    /// <inheritdoc/>
+    public string? CausationId => null;
+
+    /// <inheritdoc/>
+    public string NodeId => "canary-stub";
+
+    /// <inheritdoc/>
+    public string StudioId => "canary-studio";
+
+    /// <inheritdoc/>
+    public string Environment => "test";
+
+    /// <inheritdoc/>
+    public string? TenantId => null;
+
+    /// <inheritdoc/>
+    public string? ProjectId => null;
+
+    /// <inheritdoc/>
+    public CancellationToken Cancellation => CancellationToken.None;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> Baggage => new Dictionary<string, string>();
+
+    /// <inheritdoc/>
+    public DateTimeOffset CreatedAtUtc => DateTimeOffset.UtcNow;
+
+    /// <inheritdoc/>
+    public void AddBaggage(string key, string value)
+    {
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubOperationContext.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubOperationContext.cs
@@ -1,0 +1,66 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// A minimal <see cref="IOperationContext"/> stub that provides only a correlation ID.
+/// Does not implement real Kernel behavior — used exclusively for canary correlation mismatch testing.
+/// </summary>
+internal sealed class StubOperationContext(string correlationId) : IOperationContext
+{
+    /// <inheritdoc/>
+    public IGridContext GridContext { get; } = new StubGridContext();
+
+    /// <inheritdoc/>
+    public string OperationName => "canary-stub";
+
+    /// <inheritdoc/>
+    public string OperationId => "canary-op-id";
+
+    /// <inheritdoc/>
+    public string CorrelationId => correlationId;
+
+    /// <inheritdoc/>
+    public string? CausationId => null;
+
+    /// <inheritdoc/>
+    public string? TenantId => null;
+
+    /// <inheritdoc/>
+    public string? ProjectId => null;
+
+    /// <inheritdoc/>
+    public DateTimeOffset StartedAtUtc => DateTimeOffset.UtcNow;
+
+    /// <inheritdoc/>
+    public DateTimeOffset? CompletedAtUtc => null;
+
+    /// <inheritdoc/>
+    public bool? IsSuccess => null;
+
+    /// <inheritdoc/>
+    public string? ErrorMessage => null;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object?> Metadata => new Dictionary<string, object?>();
+
+    /// <inheritdoc/>
+    public void Complete()
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Fail(string errorMessage, Exception? exception = null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void AddMetadata(string key, object? value)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx
@@ -18,5 +18,6 @@
   </Folder>
   <Project Path="HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj" />
   <Project Path="HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj" />
+  <Project Path="HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj" />
   <Project Path="HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj" />
 </Solution>

--- a/HoneyDrunk.Web.Rest/docs/FILE_GUIDE.md
+++ b/HoneyDrunk.Web.Rest/docs/FILE_GUIDE.md
@@ -282,6 +282,10 @@ HoneyDrunk.Web.Rest/
     ├── Abstractions/                     # Contract tests
     ├── AspNetCore/                       # Middleware tests
     └── TestHost/                         # Test infrastructure
+
+└── HoneyDrunk.Web.Rest.Canary/          # Canary integration tests
+    ├── 26 tests across 5 invariants
+    └── Validates upstream contract compatibility
 ```
 
 ---
@@ -299,11 +303,18 @@ HoneyDrunk.Web.Rest/
 
 | Exception Type | HTTP Status | Error Code |
 |----------------|-------------|------------|
-| `KeyNotFoundException` | 404 Not Found | `NOT_FOUND` |
+| `JsonException` | 400 Bad Request | `BAD_REQUEST` |
+| `BadHttpRequestException` | 400 Bad Request | `BAD_REQUEST` |
 | `ArgumentException` | 400 Bad Request | `BAD_REQUEST` |
 | `ArgumentNullException` | 400 Bad Request | `BAD_REQUEST` |
+| Kernel `ValidationException` | 400 Bad Request | `BAD_REQUEST` |
 | `InvalidOperationException` | 409 Conflict | `CONFLICT` |
+| Kernel `ConcurrencyException` | 409 Conflict | `CONFLICT` |
+| `KeyNotFoundException` | 404 Not Found | `NOT_FOUND` |
+| Kernel `NotFoundException` | 404 Not Found | `NOT_FOUND` |
 | `UnauthorizedAccessException` | 403 Forbidden | `FORBIDDEN` |
+| Kernel `SecurityException` | 403 Forbidden | `FORBIDDEN` |
+| Kernel `DependencyFailureException` | 503 Service Unavailable | `SERVICE_UNAVAILABLE` |
 | `NotImplementedException` | 501 Not Implemented | `NOT_IMPLEMENTED` |
 | `OperationCanceledException` | 499 Client Closed (client aborted) | `GENERAL_ERROR` |
 | Other exceptions | 500 Internal Server Error | `INTERNAL_ERROR` |
@@ -386,5 +397,5 @@ Applications using HoneyDrunk.Web.Rest:
 
 ---
 
-*Last Updated: 2026-01-11*  
+*Last Updated: 2026-02-14*  
 *Target Framework: .NET 10.0*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ HoneyDrunk.Web.Rest provides **REST API conventions and middleware** for HoneyDr
 ```xml
 <ItemGroup>
   <!-- Full ASP.NET Core integration -->
-  <PackageReference Include="HoneyDrunk.Web.Rest.AspNetCore" Version="0.1.0" />
+  <PackageReference Include="HoneyDrunk.Web.Rest.AspNetCore" Version="0.2.0" />
   
   <!-- Or just the contracts (no runtime dependencies) -->
   <PackageReference Include="HoneyDrunk.Web.Rest.Abstractions" Version="0.1.0" />
@@ -255,9 +255,13 @@ HoneyDrunk.Web.Rest/
 |   +-- Transport/                        # Transport result extensions
 |
 +-- HoneyDrunk.Web.Rest.Tests/           # Integration tests
-    +-- Abstractions/                     # Contract tests
-    +-- AspNetCore/                       # Middleware tests
-    +-- TestHost/                         # Test infrastructure
+|   +-- Abstractions/                     # Contract tests
+|   +-- AspNetCore/                       # Middleware tests
+|   +-- TestHost/                         # Test infrastructure
+|
++-- HoneyDrunk.Web.Rest.Canary/          # Canary integration tests
+    +-- 26 tests across 5 invariants
+    +-- Validates upstream contract compatibility
 ```
 
 ---


### PR DESCRIPTION
… and canary tests

- Map JsonException, BadHttpRequestException, and Kernel exceptions (Validation, NotFound, Concurrency, Security, DependencyFailure) to specific HTTP status codes with safe messages
- Log correlation ID mismatch warnings in CorrelationMiddleware
- Guard ExceptionMappingMiddleware with Response.HasStarted
- Fallback to HttpContext.User for auth shaping if identity accessor is missing
- Add HoneyDrunk.Web.Rest.Canary with 26 integration tests for contract invariants
- Bump dependencies: Kernel.Abstractions 0.4.0, Transport 0.4.0, Auth.AspNetCore 0.2.0
- Update docs, changelog, and version to 0.2.0