### PR TITLE
chore(ci): add nightly workflows, refactor PR and publish, upgrade deps

### DIFF
--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened, labeled, unlabeled, edited]
 
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   mirror:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -1,0 +1,11 @@
+name: Hive Field Mirror
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled, edited]
+
+jobs:
+  mirror:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main
+    secrets:
+      hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}

--- a/.github/workflows/nightly-deps.yml
+++ b/.github/workflows/nightly-deps.yml
@@ -1,0 +1,21 @@
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Web.Rest'
+      project-path: './HoneyDrunk.Web.Rest.slnx'
+      check-dotnet-deps: true
+      create-update-prs: false
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -25,4 +25,4 @@ jobs:
       create-issues: true
       actions-ref: 'main'
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -1,0 +1,28 @@
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  issues: write
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Web.Rest'
+      project-path: './HoneyDrunk.Web.Rest.slnx'
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,17 +1,8 @@
-name: PR Validation
+name: PR
 
 on:
   pull_request:
-    branches: [ main, develop ]
-    paths:
-      - '**/*.cs'
-      - '**/*.csproj'
-      - '**/*.sln'
-      - '**/*.slnx'
-      - '**/*.props'
-      - '**/*.targets'
-      - '**/.editorconfig'
-      - '**/stylecop.json'
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -19,15 +10,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  pr-validation:
+  pr-core:
+    name: PR Core
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:
       dotnet-version: '10.0.x'
       configuration: 'Release'
       runs-on: 'ubuntu-latest'
       working-directory: 'HoneyDrunk.Web.Rest'
-      # Optional: target a specific solution or project
-      # project-path: './HoneyDrunk.Web.Rest.sln'
+      project-path: './HoneyDrunk.Web.Rest.slnx'
       enable-secret-scan: true
       enable-accessibility-check: false
       post-pr-summary: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,11 @@ jobs:
   release:
     name: Build, Pack & Publish
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
     with:
       dotnet-version: '10.0.x'
@@ -65,70 +70,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          ref: main
+          path: .actions
+
+      - name: Generate Release Notes
+        id: notes
+        uses: ./.actions/.github/actions/release/generate-notes
+        with:
+          version: ${{ needs.prepare.outputs.version }}
+          product-name: HoneyDrunk.Web.Rest
+          product-description: 'Standardized REST API conventions for HoneyDrunk.OS -- unified response envelopes, correlation propagation, exception mapping, and API contracts.'
+          nuget-packages: |
+            HoneyDrunk.Web.Rest.Abstractions
+            HoneyDrunk.Web.Rest.AspNetCore
+          docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest#readme'
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.version-tag }}
           name: HoneyDrunk.Web.Rest ${{ needs.prepare.outputs.version-tag }}
-          body: |
-            ## HoneyDrunk.Web.Rest ${{ needs.prepare.outputs.version-tag }}
-
-            Standardized REST API conventions for HoneyDrunk.OS - Unified response envelopes, correlation propagation, exception mapping, and API contracts for consistent REST services across the Hive.
-
-            ### 📦 Packages
-
-            **HoneyDrunk.Web.Rest.Abstractions** - Pure contracts with no dependencies
-
-            ```xml
-            <PackageReference Include="HoneyDrunk.Web.Rest.Abstractions" Version="${{ needs.prepare.outputs.version }}" />
-            ```
-
-            **HoneyDrunk.Web.Rest.AspNetCore** - ASP.NET Core integration with middleware and filters
-
-            ```xml
-            <PackageReference Include="HoneyDrunk.Web.Rest.AspNetCore" Version="${{ needs.prepare.outputs.version }}" />
-            ```
-
-            ### 🔗 Links
-            - [NuGet: HoneyDrunk.Web.Rest.Abstractions](https://www.nuget.org/packages/HoneyDrunk.Web.Rest.Abstractions/${{ needs.prepare.outputs.version }})
-            - [NuGet: HoneyDrunk.Web.Rest.AspNetCore](https://www.nuget.org/packages/HoneyDrunk.Web.Rest.AspNetCore/${{ needs.prepare.outputs.version }})
-            - [Documentation](https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest#readme)
-
-            ### 🚀 Quick Start
-
-            ```csharp
-            using HoneyDrunk.Web.Rest.AspNetCore.Extensions;
-
-            var builder = WebApplication.CreateBuilder(args);
-
-            // Register REST services
-            builder.Services.AddHoneyDrunkWebRest(options =>
-            {
-                options.EnableExceptionMapping = true;
-                options.EnableRequestLoggingScope = true;
-                options.EnableModelStateValidationFilter = true;
-                options.IncludeExceptionDetails = builder.Environment.IsDevelopment();
-            });
-
-            builder.Services.AddControllers();
-
-            var app = builder.Build();
-
-            // Add REST middleware (before routing)
-            app.UseHoneyDrunkWebRest();
-
-            app.UseRouting();
-            app.MapControllers();
-
-            app.Run();
-            ```
-
-            ### ✨ Features
-            - **Response Envelopes** - Unified `ApiResult<T>` and `ApiErrorResponse` contracts
-            - **Correlation Propagation** - `X-Correlation-Id` header handling with `ICorrelationIdAccessor`
-            - **Exception Mapping** - Automatic exception-to-HTTP-status mapping
-            - **Model Validation** - Consistent validation error responses
-            - **Pagination** - `PageRequest` and `PageResult<T>` for standardized paging
-            - **JSON Conventions** - camelCase, enum-as-string, null-omission defaults
+          body: ${{ steps.notes.outputs.body }}
+          generate_release_notes: ${{ steps.notes.outputs.has-changelog == 'false' }}
           draft: false
           prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,5 @@ jobs:
           tag_name: ${{ needs.prepare.outputs.version-tag }}
           name: HoneyDrunk.Web.Rest ${{ needs.prepare.outputs.version-tag }}
           body: ${{ steps.notes.outputs.body }}
-          generate_release_notes: ${{ steps.notes.outputs.has-changelog == 'false' }}
           draft: false
           prerelease: false

--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   weekly-deps:
@@ -18,7 +19,7 @@ jobs:
       working-directory: 'HoneyDrunk.Web.Rest'
       project-path: './HoneyDrunk.Web.Rest.slnx'
       check-dotnet-deps: true
-      create-update-prs: false
+      create-update-prs: true
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   weekly-deps:

--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -1,13 +1,17 @@
-name: Nightly Dependencies
+name: Weekly Dependencies
 
 on:
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  nightly-deps:
-    name: Nightly Dependencies
+  weekly-deps:
+    name: Weekly Dependencies
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
     with:
       dotnet-version: '10.0.x'

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,50 @@
+# ==============================================================================
+# Gitleaks configuration
+# ==============================================================================
+# Auto-discovered by gitleaks when scanning this repo. Adds allowlists for
+# documentation placeholder secrets on top of the default ruleset.
+#
+# Shared source of truth: HoneyDrunk.Actions/.github/config/gitleaks.toml
+# Keep in sync across all grid repos.
+# ==============================================================================
+
+title = "HoneyDrunk gitleaks config"
+
+[extend]
+useDefault = true
+
+# ------------------------------------------------------------------------------
+# Documentation placeholders
+# ------------------------------------------------------------------------------
+# Code samples in README/docs use obvious fake values like "test-api-key-12345"
+# or "my-api-key-12345". Gitleaks' generic-api-key rule flags them. Scope the
+# allowlist to markdown/docs paths so a real secret leaking into source is still
+# caught.
+[[allowlists]]
+description = "Documentation placeholder API keys and secrets"
+condition = "AND"
+paths = [
+  '''(?i).*\.md$''',
+  '''(?i)^docs/.*''',
+]
+regexes = [
+  '''(?i)(test|my|your|example|sample|demo|fake|placeholder|dummy|changeme|xxxx+)[-_]?api[-_]?key[-_]?[\w-]*''',
+  '''(?i)(test|my|your|example|sample|demo|fake|placeholder|dummy)[-_]?secret[-_]?[\w-]*''',
+  '''(?i)(test|my|your|example|sample|demo|fake|placeholder|dummy)[-_]?token[-_]?[\w-]*''',
+]
+
+# ------------------------------------------------------------------------------
+# Hex identifiers in documentation
+# ------------------------------------------------------------------------------
+# Azure Key Vault secret versions are 32-char hex strings and are legitimately
+# shown in docs as example identifiers (not secrets). Allow only inside docs.
+[[allowlists]]
+description = "Hex identifiers in docs (e.g. AKV secret version IDs)"
+condition = "AND"
+paths = [
+  '''(?i).*\.md$''',
+  '''(?i)^docs/.*''',
+]
+regexes = [
+  '''^[a-f0-9]{32}$''',
+]

--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -1,0 +1,46 @@
+# HoneyDrunk.Web.Rest - Repository Changelog
+
+All notable changes to the HoneyDrunk.Web.Rest repository will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**Note:** See individual package CHANGELOGs for detailed changes:
+- [HoneyDrunk.Web.Rest.Abstractions CHANGELOG](HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md)
+- [HoneyDrunk.Web.Rest.AspNetCore CHANGELOG](HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md)
+
+---
+
+## [0.2.0] - 2026-02-14
+
+### Added
+
+- Exception mapping for Kernel typed exceptions (`ValidationException` → 400, `NotFoundException` → 404, `ConcurrencyException` → 409, `SecurityException` → 403, `DependencyFailureException` → 503)
+- `JsonException` and `BadHttpRequestException` mapping to 400 Bad Request
+- `ExceptionMappingMiddleware` guards against `Response.HasStarted`
+- `CorrelationMiddleware` logs warning when Kernel and header correlation IDs differ
+- `RestAuthorizationResultHandler` falls back to `HttpContext.User.Identity.IsAuthenticated`
+- `PolicyNotFound` authorization deny code
+
+### Changed
+
+- Updated HoneyDrunk.Kernel.Abstractions from 0.3.0 to 0.4.0
+- Updated HoneyDrunk.Transport from 0.3.0 to 0.4.0
+- Updated HoneyDrunk.Auth.AspNetCore from 0.1.0 to 0.2.0
+
+## [0.1.0] - 2026-01-10
+
+### Added
+
+- Initial release of HoneyDrunk.Web.Rest
+- `ApiResult` / `ApiResult<T>` result envelopes with standard status codes
+- `ApiError`, `ApiErrorCode`, `ApiErrorResponse`, `ValidationError` error types
+- `PageRequest` / `PageResult<T>` pagination primitives
+- Standard header names and media type constants
+- Telemetry tag constants for observability
+- ASP.NET Core integration: `CorrelationMiddleware`, `ExceptionMappingMiddleware`, `RequestLoggingMiddleware`
+- `RestOptions` for configurable middleware behavior
+- Fluent `AddHoneyDrunkWebRest()` service registration with Kernel and Auth integration
+
+[0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
+[0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
@@ -29,14 +29,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.2.0" />
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
@@ -9,14 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -35,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
@@ -9,13 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -34,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx
@@ -14,7 +14,7 @@
   </Folder>
   <Folder Name="/Pipelines/">
     <File Path="../.github/workflows/publish.yml" />
-    <File Path="../.github/workflows/validate-pr.yml" />
+    <File Path="../.github/workflows/pr.yml" />
   </Folder>
   <Project Path="HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj" />
   <Project Path="HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj" />

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx
@@ -14,7 +14,10 @@
   </Folder>
   <Folder Name="/Pipelines/">
     <File Path="../.github/workflows/publish.yml" />
+    <File Path="../.github/workflows/hive-field-mirror.yml" />
+    <File Path="../.github/workflows/nightly-security.yml" />
     <File Path="../.github/workflows/pr.yml" />
+    <File Path="../.github/workflows/weekly-deps.yml" />
   </Folder>
   <Project Path="HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj" />
   <Project Path="HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj" />


### PR DESCRIPTION
Introduce nightly security and dependency workflows, Hive Field mirror, and replace validate-pr.yml with pr.yml targeting main. Refactor publish.yml to use reusable release notes action and improve permissions. Upgrade HoneyDrunk.Standards, analyzers, and test dependencies across all projects. Add repository-level CHANGELOG.md. Update solution file references.