### PR TITLE
feat(webrest): add ADR-0005/0006 bootstrap and vault invalidation

### DIFF
--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-04-25
+
+### Added
+
+- Added ADR-0005/0006 Web.Rest bootstrap support for env-var-driven Azure Key Vault and Azure App Configuration through `AddWebRestBootstrap()`.
+- Added `/internal/vault/invalidate` endpoint mapping via `MapHoneyDrunkWebRestVaultInvalidationWebhook()` for Event Grid cache invalidation.
+- Added canary coverage for Key Vault `SecretNewVersionCreated` invalidation using `{Provider}--{Key}` secret names.
+
+### Changed
+
+- Updated `HoneyDrunk.Web.Rest.AspNetCore` to consume the Vault Azure Key Vault, App Configuration, and Event Grid provider packages.
+
 ## [0.2.0] - 2026-02-14
 
 ### Added
@@ -42,5 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RestOptions` for configurable middleware behavior
 - Fluent `AddHoneyDrunkWebRest()` service registration with Kernel and Auth integration
 
+[0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Web.Rest.Abstractions will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-25
+
+### Changed
+- Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.3.0
+- No API surface changes
+
 ## [0.2.0] - 2026-02-14
 
 ### Changed
@@ -46,5 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All types are immutable records for thread safety
 - JSON serialization attributes included for consistent output
 
+[0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.Abstractions</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Pure contracts and constants for HoneyDrunk REST services. Provides standardized response envelopes (ApiResult, ApiErrorResponse), pagination contracts (PageRequest, PageResult), error codes, and telemetry tags. Zero runtime dependencies - can be used in any .NET project.</Description>
-    <PackageReleaseNotes>v0.2.0: Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.2.0. No API changes.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.3.0. No API changes.</PackageReleaseNotes>
     <PackageTags>rest;api;contracts;response;envelope;error;pagination;validation;constants;abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Paging/PageResult.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Paging/PageResult.cs
@@ -69,11 +69,11 @@ public sealed record PageResult<T>
         int pageNumber,
         int pageSize,
         long totalCount) => new()
-    {
-        Items = items,
-        PageNumber = pageNumber,
-        PageSize = pageSize,
-        TotalCount = totalCount,
-    };
+        {
+            Items = items,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+            TotalCount = totalCount,
+        };
 #pragma warning restore CA1000
 }

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResult.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResult.cs
@@ -64,11 +64,11 @@ public record ApiResult
         string message,
         string code = ApiErrorCode.GeneralError,
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Failed,
-        Error = new ApiError { Code = code, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Failed,
+            Error = new ApiError { Code = code, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates a not found <see cref="ApiResult"/>.
@@ -79,11 +79,11 @@ public record ApiResult
     public static ApiResult NotFound(
         string message = "The requested resource was not found.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.NotFound,
-        Error = new ApiError { Code = ApiErrorCode.NotFound, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.NotFound,
+            Error = new ApiError { Code = ApiErrorCode.NotFound, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates an unauthorized <see cref="ApiResult"/>.
@@ -94,11 +94,11 @@ public record ApiResult
     public static ApiResult Unauthorized(
         string message = "Authentication is required.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Unauthorized,
-        Error = new ApiError { Code = ApiErrorCode.Unauthorized, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Unauthorized,
+            Error = new ApiError { Code = ApiErrorCode.Unauthorized, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates a forbidden <see cref="ApiResult"/>.
@@ -109,11 +109,11 @@ public record ApiResult
     public static ApiResult Forbidden(
         string message = "You do not have permission to access this resource.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Forbidden,
-        Error = new ApiError { Code = ApiErrorCode.Forbidden, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Forbidden,
+            Error = new ApiError { Code = ApiErrorCode.Forbidden, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates a conflict <see cref="ApiResult"/>.
@@ -124,11 +124,11 @@ public record ApiResult
     public static ApiResult Conflict(
         string message,
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Conflict,
-        Error = new ApiError { Code = ApiErrorCode.Conflict, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Conflict,
+            Error = new ApiError { Code = ApiErrorCode.Conflict, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates an error <see cref="ApiResult"/>.
@@ -139,9 +139,9 @@ public record ApiResult
     public static ApiResult InternalError(
         string message = "An internal server error occurred.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Error,
-        Error = new ApiError { Code = ApiErrorCode.InternalError, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Error,
+            Error = new ApiError { Code = ApiErrorCode.InternalError, Message = message },
+            CorrelationId = correlationId,
+        };
 }

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResultOfT.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResultOfT.cs
@@ -41,11 +41,11 @@ public record ApiResult<T> : ApiResult
         string message,
         string code = ApiErrorCode.GeneralError,
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Failed,
-        Error = new ApiError { Code = code, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Failed,
+            Error = new ApiError { Code = code, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates a not found <see cref="ApiResult{T}"/>.
@@ -56,11 +56,11 @@ public record ApiResult<T> : ApiResult
     public static new ApiResult<T> NotFound(
         string message = "The requested resource was not found.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.NotFound,
-        Error = new ApiError { Code = ApiErrorCode.NotFound, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.NotFound,
+            Error = new ApiError { Code = ApiErrorCode.NotFound, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates an unauthorized <see cref="ApiResult{T}"/>.
@@ -71,11 +71,11 @@ public record ApiResult<T> : ApiResult
     public static new ApiResult<T> Unauthorized(
         string message = "Authentication is required.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Unauthorized,
-        Error = new ApiError { Code = ApiErrorCode.Unauthorized, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Unauthorized,
+            Error = new ApiError { Code = ApiErrorCode.Unauthorized, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates a forbidden <see cref="ApiResult{T}"/>.
@@ -86,11 +86,11 @@ public record ApiResult<T> : ApiResult
     public static new ApiResult<T> Forbidden(
         string message = "You do not have permission to access this resource.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Forbidden,
-        Error = new ApiError { Code = ApiErrorCode.Forbidden, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Forbidden,
+            Error = new ApiError { Code = ApiErrorCode.Forbidden, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates a conflict <see cref="ApiResult{T}"/>.
@@ -101,11 +101,11 @@ public record ApiResult<T> : ApiResult
     public static new ApiResult<T> Conflict(
         string message,
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Conflict,
-        Error = new ApiError { Code = ApiErrorCode.Conflict, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Conflict,
+            Error = new ApiError { Code = ApiErrorCode.Conflict, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Creates an error <see cref="ApiResult{T}"/>.
@@ -116,11 +116,11 @@ public record ApiResult<T> : ApiResult
     public static new ApiResult<T> InternalError(
         string message = "An internal server error occurred.",
         string? correlationId = null) => new()
-    {
-        Status = ApiResultStatus.Error,
-        Error = new ApiError { Code = ApiErrorCode.InternalError, Message = message },
-        CorrelationId = correlationId,
-    };
+        {
+            Status = ApiResultStatus.Error,
+            Error = new ApiError { Code = ApiErrorCode.InternalError, Message = message },
+            CorrelationId = correlationId,
+        };
 
     /// <summary>
     /// Converts from a non-generic <see cref="ApiResult"/> to a generic <see cref="ApiResult{T}"/>.

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to HoneyDrunk.Web.Rest.AspNetCore will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-25
+
+### Added
+
+#### Bootstrap
+- `AddWebRestBootstrap()` for ADR-0005 startup wiring with env-var-driven Azure Key Vault and Azure App Configuration.
+- `MapHoneyDrunkWebRestVaultInvalidationWebhook()` for the ADR-0006 `/internal/vault/invalidate` Event Grid webhook.
+
+#### Dependencies
+- Added `HoneyDrunk.Vault.EventGrid` 0.3.0.
+- Added `HoneyDrunk.Vault.Providers.AppConfiguration` 0.3.0.
+- Added `HoneyDrunk.Vault.Providers.AzureKeyVault` 0.3.0.
+
 ## [0.2.0] - 2026-02-14
 
 ### Changed
@@ -130,5 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kernel/Auth/Transport integrations are optional - middleware gracefully degrades when not registered
 - Auth failure shaping uses `IAuthorizationMiddlewareResultHandler` for scheme-agnostic 401/403 handling
 
+[0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Extensions/HoneyDrunkWebRestBuilderExtensions.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Extensions/HoneyDrunkWebRestBuilderExtensions.cs
@@ -1,0 +1,34 @@
+using HoneyDrunk.Kernel.Abstractions.Hosting;
+using HoneyDrunk.Vault.EventGrid.Extensions;
+using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+
+namespace HoneyDrunk.Web.Rest.AspNetCore.Extensions;
+
+/// <summary>
+/// Extension methods for bootstrapping HoneyDrunk Web.Rest in deployable nodes.
+/// </summary>
+public static class HoneyDrunkWebRestBuilderExtensions
+{
+    /// <summary>
+    /// Adds ADR-0005 compliant Web.Rest bootstrap wiring.
+    /// </summary>
+    /// <param name="builder">The HoneyDrunk builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    /// <remarks>
+    /// This wires Key Vault from <c>AZURE_KEYVAULT_URI</c>, App Configuration from
+    /// <c>AZURE_APPCONFIG_ENDPOINT</c> using the <c>HONEYDRUNK_NODE_ID</c> label, Web.Rest services,
+    /// and the services required by the ADR-0006 Vault invalidation webhook.
+    /// </remarks>
+    public static IHoneyDrunkBuilder AddWebRestBootstrap(this IHoneyDrunkBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddVaultWithAzureKeyVaultBootstrap();
+        builder.AddAppConfiguration();
+        builder.Services.AddRest();
+        builder.Services.AddVaultEventGridInvalidation();
+
+        return builder;
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Extensions/HoneyDrunkWebRestEndpointRouteBuilderExtensions.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Extensions/HoneyDrunkWebRestEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using HoneyDrunk.Vault.EventGrid.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace HoneyDrunk.Web.Rest.AspNetCore.Extensions;
+
+/// <summary>
+/// Extension methods for mapping HoneyDrunk Web.Rest internal endpoints.
+/// </summary>
+public static class HoneyDrunkWebRestEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the internal Vault invalidation webhook used by Event Grid secret rotation notifications.
+    /// </summary>
+    /// <param name="endpoints">The route builder.</param>
+    /// <returns>The endpoint convention builder.</returns>
+    public static IEndpointConventionBuilder MapHoneyDrunkWebRestVaultInvalidationWebhook(
+        this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        return endpoints.MapVaultInvalidationWebhook("/internal/vault/invalidate");
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.AspNetCore</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>ASP.NET Core integration for HoneyDrunk REST conventions. Provides middleware for correlation propagation, exception mapping, and request logging. Includes MVC filters for model validation, minimal API endpoint conventions, and JSON serialization defaults. Ensures consistent API responses across all services.</Description>
-    <PackageReleaseNotes>v0.2.0: Added JsonException/BadHttpRequestException to 400 mapping, Kernel typed exception mappings (ValidationException, NotFoundException, ConcurrencyException, SecurityException, DependencyFailureException), HasStarted guard in ExceptionMappingMiddleware, correlation mismatch warning logging, and auth HttpContext.User fallback. Bumped Kernel.Abstractions to 0.4.0, Transport to 0.4.0, Auth.AspNetCore to 0.2.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Added ADR-0005/0006 bootstrap helpers for env-var-driven Azure Key Vault, App Configuration label partitioning, and Event Grid Vault cache invalidation webhook registration.</PackageReleaseNotes>
     <PackageTags>rest;api;aspnetcore;middleware;correlation;exception;validation;filter;json;conventions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -29,13 +29,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.2.0" />
+    <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.3.0" />
+
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="HoneyDrunk.Transport" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.3.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.3.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
@@ -27,7 +27,30 @@ app.MapControllers();
 app.Run();
 ```
 
+For deployable HoneyDrunk nodes, use the ADR-0005/0006 bootstrap helper with `AZURE_KEYVAULT_URI`,
+`AZURE_APPCONFIG_ENDPOINT`, and `HONEYDRUNK_NODE_ID` supplied by the host environment:
+
+```csharp
+builder.Services.AddHoneyDrunkNode(options =>
+{
+    options.NodeId = new("honeydrunk-web-rest");
+    // Configure the remaining node identity options here.
+})
+.AddWebRestBootstrap();
+
+var app = builder.Build();
+app.MapHoneyDrunkWebRestVaultInvalidationWebhook();
+```
+
 ## Features
+
+### ADR-0005/0006 Bootstrap
+
+- Reads Key Vault location from `AZURE_KEYVAULT_URI`
+- Reads shared App Configuration location from `AZURE_APPCONFIG_ENDPOINT`
+- Uses `HONEYDRUNK_NODE_ID` as the App Configuration label, for example `honeydrunk-web-rest`
+- Registers the Event Grid `/internal/vault/invalidate` webhook for Vault cache invalidation
+- Keeps application secrets behind `ISecretStore`; no Web.Rest source reads secret values from `IConfiguration`
 
 ### Correlation ID Propagation
 
@@ -141,4 +164,7 @@ app.MapDelete("/api/items/{id}", DeleteItemAsync)
 - HoneyDrunk.Kernel.Abstractions 0.4.0 (optional, for Grid context and typed exceptions)
 - HoneyDrunk.Auth.AspNetCore 0.2.0 (optional, for identity context)
 - HoneyDrunk.Transport 0.4.0 (optional, for envelope mapping)
+- HoneyDrunk.Vault.EventGrid 0.3.0 (for cache invalidation webhook mapping)
+- HoneyDrunk.Vault.Providers.AppConfiguration 0.3.0 (for env-var-driven App Configuration bootstrap)
+- HoneyDrunk.Vault.Providers.AzureKeyVault 0.3.0 (for env-var-driven Key Vault bootstrap)
 - Microsoft.AspNetCore.App (framework reference)

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
@@ -162,7 +162,7 @@ app.MapDelete("/api/items/{id}", DeleteItemAsync)
 
 - HoneyDrunk.Web.Rest.Abstractions (contracts)
 - HoneyDrunk.Kernel.Abstractions 0.4.0 (optional, for Grid context and typed exceptions)
-- HoneyDrunk.Auth.AspNetCore 0.2.0 (optional, for identity context)
+- HoneyDrunk.Auth.AspNetCore 0.3.0 (optional, for identity context)
 - HoneyDrunk.Transport 0.4.0 (optional, for envelope mapping)
 - HoneyDrunk.Vault.EventGrid 0.3.0 (for cache invalidation webhook mapping)
 - HoneyDrunk.Vault.Providers.AppConfiguration 0.3.0 (for env-var-driven App Configuration bootstrap)

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
@@ -1,4 +1,7 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.EventGrid.Extensions;
+using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Web.Rest.AspNetCore.Extensions;
 using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
 using Microsoft.AspNetCore.Builder;
@@ -38,6 +41,16 @@ internal sealed class CanaryHostFactory : IDisposable
     /// endpoint but NO <c>IAuthenticatedIdentityAccessor</c>, forcing the fallback to HttpContext.User.
     /// </summary>
     public bool UseAuthWithoutIdentityAccessor { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to register the Vault invalidation webhook canary endpoint.
+    /// </summary>
+    public bool EnableVaultInvalidationWebhook { get; set; }
+
+    /// <summary>
+    /// Gets the cache invalidator used by the Vault invalidation webhook canary.
+    /// </summary>
+    public RecordingSecretCacheInvalidator VaultCacheInvalidator { get; } = new();
 
     /// <summary>
     /// Creates an HTTP client backed by the in-process test server.
@@ -87,6 +100,13 @@ internal sealed class CanaryHostFactory : IDisposable
                         services.AddAuthorizationBuilder()
                             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));
                     }
+
+                    if (EnableVaultInvalidationWebhook)
+                    {
+                        services.AddSingleton<ISecretStore>(new SharedSecretStore());
+                        services.AddSingleton<ISecretCacheInvalidator>(VaultCacheInvalidator);
+                        services.AddVaultEventGridInvalidation();
+                    }
                 });
 
                 webBuilder.Configure(app =>
@@ -103,6 +123,11 @@ internal sealed class CanaryHostFactory : IDisposable
                     app.UseEndpoints(endpoints =>
                     {
                         endpoints.MapCanaryEndpoints();
+
+                        if (EnableVaultInvalidationWebhook)
+                        {
+                            endpoints.MapHoneyDrunkWebRestVaultInvalidationWebhook();
+                        }
 
                         if (UseAuthWithoutIdentityAccessor)
                         {
@@ -129,5 +154,46 @@ internal sealed class CanaryHostFactory : IDisposable
     {
         _client?.Dispose();
         _host?.Dispose();
+    }
+
+    internal sealed class RecordingSecretCacheInvalidator : ISecretCacheInvalidator
+    {
+        public List<string> InvalidatedSecrets { get; } = [];
+
+        public void Invalidate(string secretName)
+        {
+            InvalidatedSecrets.Add(secretName);
+        }
+
+        public void InvalidateAll()
+        {
+            InvalidatedSecrets.Add("*");
+        }
+    }
+
+    private sealed class SharedSecretStore : ISecretStore
+    {
+        public const string SharedSecretValue = "expected-shared-secret";
+
+        public Task<SecretValue> GetSecretAsync(
+            SecretIdentifier identifier,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new SecretValue(identifier, SharedSecretValue, "v1"));
+        }
+
+        public Task<VaultResult<SecretValue>> TryGetSecretAsync(
+            SecretIdentifier identifier,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(VaultResult.Success(new SecretValue(identifier, SharedSecretValue, "v1")));
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(
+            string secretName,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<SecretVersion>>([]);
+        }
     }
 }

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/VaultInvalidationWebhookCanary.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/VaultInvalidationWebhookCanary.cs
@@ -1,0 +1,60 @@
+using HoneyDrunk.Vault.EventGrid.Constants;
+using Shouldly;
+using System.Net;
+using System.Text;
+
+namespace HoneyDrunk.Web.Rest.Canary;
+
+/// <summary>
+/// ADR-0006: Vault invalidation webhook registration and Event Grid cache invalidation behavior.
+/// </summary>
+public sealed class VaultInvalidationWebhookCanary
+{
+    /// <summary>
+    /// Verifies that the Web.Rest invalidation endpoint accepts Event Grid events and invalidates the named secret.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task VaultInvalidationWebhook_InvalidatesSecret_ForKeyVaultSecretNewVersionEvent()
+    {
+        using CanaryHostFactory factory = new()
+        {
+            EnableVaultInvalidationWebhook = true,
+        };
+
+        HttpClient client = factory.CreateClient();
+        const string secretName = "DownstreamApi--ApiKey";
+        const string requestBody =
+            """
+            [
+              {
+                "id": "evt-secret-1",
+                "eventType": "Microsoft.KeyVault.SecretNewVersionCreated",
+                "subject": "DownstreamApi--ApiKey",
+                "eventTime": "2026-04-12T12:00:00Z",
+                "data": {
+                  "id": "https://kv-hd-webrest-dev.vault.azure.net/secrets/DownstreamApi--ApiKey/version1",
+                  "vaultName": "kv-hd-webrest-dev",
+                  "objectType": "Secret",
+                  "objectName": "DownstreamApi--ApiKey"
+                },
+                "dataVersion": "1",
+                "metadataVersion": "1"
+              }
+            ]
+            """;
+
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            new Uri("/internal/vault/invalidate", UriKind.Relative));
+        request.Headers.Add(
+            VaultInvalidationWebhookConstants.SharedSecretHeaderName,
+            "expected-shared-secret");
+        request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        factory.VaultCacheInvalidator.InvalidatedSecrets.ShouldContain(secretName);
+    }
+}


### PR DESCRIPTION
introduce AddWebRestBootstrap() for env-var-driven Azure Key Vault, App Configuration, and Event Grid cache invalidation; add MapHoneyDrunkWebRestVaultInvalidationWebhook() for /internal/vault/invalidate; bump to 0.3.0; update docs and add canary test for webhook