### PR TITLE
feat: adopt typed TenantId in request logging scope

### DIFF
--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+
+- Updated `HoneyDrunk.Kernel.Abstractions` from 0.4.0 to 0.5.0 for typed `TenantId` context adoption.
+- Updated `HoneyDrunk.Transport` from 0.4.0 to 0.5.0.
+- `RequestLoggingScopeMiddleware` now omits the `TenantId` log-scope property for Internal-tenant requests and emits the sanitized ULID string for non-Internal requests.
+
 ## [0.3.0] - 2026-04-25
 
 ### Added
@@ -54,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RestOptions` for configurable middleware behavior
 - Fluent `AddHoneyDrunkWebRest()` service registration with Kernel and Auth integration
 
+[0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.Abstractions</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Pure contracts and constants for HoneyDrunk REST services. Provides standardized response envelopes (ApiResult, ApiErrorResponse), pagination contracts (PageRequest, PageResult), error codes, and telemetry tags. Zero runtime dependencies - can be used in any .NET project.</Description>
-    <PackageReleaseNotes>v0.3.0: Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.3.0. No API changes.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.4.0. No API changes.</PackageReleaseNotes>
     <PackageTags>rest;api;contracts;response;envelope;error;pagination;validation;constants;abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to HoneyDrunk.Web.Rest.AspNetCore will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+
+#### Middleware
+- `RequestLoggingScopeMiddleware` now reads Kernel's typed `TenantId` and omits the `TenantId` log-scope property for Internal-tenant requests.
+- Non-Internal tenant requests continue to emit `TenantId` as the sanitized ULID string.
+- `ProjectId` and the remaining Kernel scope properties are unchanged.
+
+#### Dependencies
+- Bumped `HoneyDrunk.Kernel.Abstractions` from 0.4.0 to 0.5.0.
+- Bumped `HoneyDrunk.Transport` from 0.4.0 to 0.5.0.
+
 ## [0.3.0] - 2026-04-25
 
 ### Added
@@ -143,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kernel/Auth/Transport integrations are optional - middleware gracefully degrades when not registered
 - Auth failure shaping uses `IAuthorizationMiddlewareResultHandler` for scheme-agnostic 401/403 handling
 
+[0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.AspNetCore</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>ASP.NET Core integration for HoneyDrunk REST conventions. Provides middleware for correlation propagation, exception mapping, and request logging. Includes MVC filters for model validation, minimal API endpoint conventions, and JSON serialization defaults. Ensures consistent API responses across all services.</Description>
-    <PackageReleaseNotes>v0.3.0: Added ADR-0005/0006 bootstrap helpers for env-var-driven Azure Key Vault, App Configuration label partitioning, and Event Grid Vault cache invalidation webhook registration.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Adopted Kernel 0.5.0 typed TenantId in request logging scopes and omitted TenantId for Internal-tenant requests.</PackageReleaseNotes>
     <PackageTags>rest;api;aspnetcore;middleware;correlation;exception;validation;filter;json;conventions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -31,12 +31,12 @@
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.3.0" />
 
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Transport" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Transport" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.3.0" />
     <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.3.0" />
     <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.3.0" />

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/RequestLoggingScopeMiddleware.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/RequestLoggingScopeMiddleware.cs
@@ -93,10 +93,10 @@ public sealed class RequestLoggingScopeMiddleware(
             scopeState["CausationId"] = LogValueSanitizer.Sanitize(operationContext.CausationId);
         }
 
-        // Add tenant/project context
-        if (!string.IsNullOrWhiteSpace(operationContext.TenantId))
+        // Add tenant context for non-internal traffic.
+        if (!operationContext.TenantId.IsInternal)
         {
-            scopeState[RestTelemetryTags.TenantId] = LogValueSanitizer.Sanitize(operationContext.TenantId);
+            scopeState[RestTelemetryTags.TenantId] = LogValueSanitizer.Sanitize(operationContext.TenantId.ToString());
         }
 
         if (!string.IsNullOrWhiteSpace(operationContext.ProjectId))

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
@@ -69,6 +69,7 @@ When `HoneyDrunk.Kernel` is registered, the middleware automatically:
   - `OperationId`, `OperationName`, `CausationId`
   - `TenantId`, `ProjectId`
   - `NodeId`, `StudioId`, `Environment` (from `IGridContext`)
+- Emits `TenantId` only for non-Internal requests; Internal-tenant traffic is represented by the absence of the property.
 
 ### Auth Integration
 
@@ -161,9 +162,9 @@ app.MapDelete("/api/items/{id}", DeleteItemAsync)
 ## Dependencies
 
 - HoneyDrunk.Web.Rest.Abstractions (contracts)
-- HoneyDrunk.Kernel.Abstractions 0.4.0 (optional, for Grid context and typed exceptions)
+- HoneyDrunk.Kernel.Abstractions 0.5.0 (optional, for Grid context and typed exceptions)
 - HoneyDrunk.Auth.AspNetCore 0.3.0 (optional, for identity context)
-- HoneyDrunk.Transport 0.4.0 (optional, for envelope mapping)
+- HoneyDrunk.Transport 0.5.0 (optional, for envelope mapping)
 - HoneyDrunk.Vault.EventGrid 0.3.0 (for cache invalidation webhook mapping)
 - HoneyDrunk.Vault.Providers.AppConfiguration 0.3.0 (for env-var-driven App Configuration bootstrap)
 - HoneyDrunk.Vault.Providers.AzureKeyVault 0.3.0 (for env-var-driven Key Vault bootstrap)

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubGridContext.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubGridContext.cs
@@ -1,4 +1,5 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
 
 namespace HoneyDrunk.Web.Rest.Canary;
 
@@ -28,7 +29,7 @@ internal sealed class StubGridContext : IGridContext
     public string Environment => "test";
 
     /// <inheritdoc/>
-    public string? TenantId => null;
+    public TenantId TenantId => TenantId.Internal;
 
     /// <inheritdoc/>
     public string? ProjectId => null;

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubOperationContext.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubOperationContext.cs
@@ -1,4 +1,5 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
 
 namespace HoneyDrunk.Web.Rest.Canary;
 
@@ -24,7 +25,7 @@ internal sealed class StubOperationContext(string correlationId) : IOperationCon
     public string? CausationId => null;
 
     /// <inheritdoc/>
-    public string? TenantId => null;
+    public TenantId TenantId => TenantId.Internal;
 
     /// <inheritdoc/>
     public string? ProjectId => null;

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/RequestLoggingScopeMiddlewareTests.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/RequestLoggingScopeMiddlewareTests.cs
@@ -19,7 +19,8 @@ public sealed class RequestLoggingScopeMiddlewareTests
 {
     /// <summary>
     /// Verifies that Internal tenant contexts omit the TenantId scope entry.
-    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
     public async Task InvokeAsync_WithInternalTenant_OmitsTenantIdScopeEntry()
     {
@@ -32,7 +33,8 @@ public sealed class RequestLoggingScopeMiddlewareTests
 
     /// <summary>
     /// Verifies that non-internal tenant contexts emit the TenantId scope entry as a ULID string.
-    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
     public async Task InvokeAsync_WithNonInternalTenant_EmitsTenantIdScopeEntryAsUlidString()
     {
@@ -46,7 +48,8 @@ public sealed class RequestLoggingScopeMiddlewareTests
 
     /// <summary>
     /// Verifies that ProjectId scope behavior remains unchanged.
-    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
     public async Task InvokeAsync_WithProjectId_PreservesProjectIdBehavior()
     {
@@ -62,7 +65,8 @@ public sealed class RequestLoggingScopeMiddlewareTests
 
     /// <summary>
     /// Verifies that existing scope properties continue to be emitted.
-    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
     public async Task InvokeAsync_WithKernelContext_PreservesOtherScopeProperties()
     {

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/RequestLoggingScopeMiddlewareTests.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/RequestLoggingScopeMiddlewareTests.cs
@@ -1,0 +1,246 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Web.Rest.Abstractions.Telemetry;
+using HoneyDrunk.Web.Rest.AspNetCore.Configuration;
+using HoneyDrunk.Web.Rest.AspNetCore.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace HoneyDrunk.Web.Rest.Tests.AspNetCore;
+
+/// <summary>
+/// Tests for request logging scope enrichment.
+/// </summary>
+public sealed class RequestLoggingScopeMiddlewareTests
+{
+    /// <summary>
+    /// Verifies that Internal tenant contexts omit the TenantId scope entry.
+    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InvokeAsync_WithInternalTenant_OmitsTenantIdScopeEntry()
+    {
+        TestOperationContext operationContext = new(TenantId.Internal);
+
+        Dictionary<string, object?> scopeState = await InvokeAndCaptureScopeAsync(operationContext);
+
+        scopeState.ContainsKey(RestTelemetryTags.TenantId).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Verifies that non-internal tenant contexts emit the TenantId scope entry as a ULID string.
+    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InvokeAsync_WithNonInternalTenant_EmitsTenantIdScopeEntryAsUlidString()
+    {
+        TenantId tenantId = TenantId.NewId();
+        TestOperationContext operationContext = new(tenantId);
+
+        Dictionary<string, object?> scopeState = await InvokeAndCaptureScopeAsync(operationContext);
+
+        scopeState[RestTelemetryTags.TenantId].ShouldBe(tenantId.ToString());
+    }
+
+    /// <summary>
+    /// Verifies that ProjectId scope behavior remains unchanged.
+    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InvokeAsync_WithProjectId_PreservesProjectIdBehavior()
+    {
+        TestOperationContext withProject = new(TenantId.NewId()) { ProjectIdValue = "project-123" };
+        TestOperationContext withoutProject = new(TenantId.NewId()) { ProjectIdValue = null };
+
+        Dictionary<string, object?> withProjectScope = await InvokeAndCaptureScopeAsync(withProject);
+        Dictionary<string, object?> withoutProjectScope = await InvokeAndCaptureScopeAsync(withoutProject);
+
+        withProjectScope["ProjectId"].ShouldBe("project-123");
+        withoutProjectScope.ContainsKey("ProjectId").ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Verifies that existing scope properties continue to be emitted.
+    /// </summary>`r`n    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InvokeAsync_WithKernelContext_PreservesOtherScopeProperties()
+    {
+        TestOperationContext operationContext = new(TenantId.NewId())
+        {
+            OperationIdValue = "operation-123",
+            OperationNameValue = "request-test",
+            CausationIdValue = "causation-123",
+            GridContextValue = new TestGridContext(TenantId.NewId())
+            {
+                NodeIdValue = "node-123",
+                StudioIdValue = "studio-123",
+                EnvironmentValue = "test",
+            },
+        };
+
+        Dictionary<string, object?> scopeState = await InvokeAndCaptureScopeAsync(operationContext);
+
+        scopeState[RestTelemetryTags.CorrelationId].ShouldBe("correlation-123");
+        scopeState[RestTelemetryTags.HttpMethod].ShouldBe("POST");
+        scopeState[RestTelemetryTags.HttpPath].ShouldBe("/scope-test");
+        scopeState[RestTelemetryTags.RequestId].ShouldBe("trace-123");
+        scopeState["OperationId"].ShouldBe("operation-123");
+        scopeState["OperationName"].ShouldBe("request-test");
+        scopeState["CausationId"].ShouldBe("causation-123");
+        scopeState["NodeId"].ShouldBe("node-123");
+        scopeState["StudioId"].ShouldBe("studio-123");
+        scopeState["Environment"].ShouldBe("test");
+    }
+
+    private static async Task<Dictionary<string, object?>> InvokeAndCaptureScopeAsync(TestOperationContext operationContext)
+    {
+        CapturingLogger<RequestLoggingScopeMiddleware> logger = new();
+        RequestLoggingScopeMiddleware middleware = new(
+            _ => Task.CompletedTask,
+            logger,
+            Options.Create(new RestOptions { IncludeTraceId = false }));
+
+        CorrelationIdAccessor correlationIdAccessor = new();
+        correlationIdAccessor.SetCorrelationId("correlation-123");
+
+        ServiceProvider services = new ServiceCollection()
+            .AddSingleton<IOperationContextAccessor>(new TestOperationContextAccessor { Current = operationContext })
+            .BuildServiceProvider();
+
+        try
+        {
+            DefaultHttpContext context = new() { RequestServices = services, TraceIdentifier = "trace-123" };
+            context.Request.Method = "POST";
+            context.Request.Path = "/scope-test";
+
+            await middleware.InvokeAsync(context, correlationIdAccessor).ConfigureAwait(false);
+        }
+        finally
+        {
+            await services.DisposeAsync().ConfigureAwait(false);
+        }
+
+        return logger.ScopeState.ShouldNotBeNull();
+    }
+
+    private sealed class TestOperationContextAccessor : IOperationContextAccessor
+    {
+        public IOperationContext? Current { get; set; }
+    }
+
+    private sealed class TestOperationContext(TenantId tenantId) : IOperationContext
+    {
+        public IGridContext GridContextValue { get; init; } = new TestGridContext(tenantId);
+
+        public string OperationNameValue { get; init; } = "operation-name";
+
+        public string OperationIdValue { get; init; } = "operation-id";
+
+        public string? CausationIdValue { get; init; }
+
+        public string? ProjectIdValue { get; init; }
+
+        public IGridContext GridContext => GridContextValue;
+
+        public string OperationName => OperationNameValue;
+
+        public string OperationId => OperationIdValue;
+
+        public string CorrelationId => GridContext.CorrelationId;
+
+        public string? CausationId => CausationIdValue;
+
+        public TenantId TenantId => tenantId;
+
+        public string? ProjectId => ProjectIdValue;
+
+        public DateTimeOffset StartedAtUtc { get; } = DateTimeOffset.UtcNow;
+
+        public DateTimeOffset? CompletedAtUtc => null;
+
+        public bool? IsSuccess => null;
+
+        public string? ErrorMessage => null;
+
+        public IReadOnlyDictionary<string, object?> Metadata { get; } = new Dictionary<string, object?>();
+
+        public void Complete()
+        {
+        }
+
+        public void Fail(string errorMessage, Exception? exception = null)
+        {
+        }
+
+        public void AddMetadata(string key, object? value)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestGridContext(TenantId tenantId) : IGridContext
+    {
+        public bool IsInitialized => true;
+
+        public string CorrelationId => "correlation-123";
+
+        public string? CausationId => null;
+
+        public string NodeIdValue { get; init; } = "node-id";
+
+        public string StudioIdValue { get; init; } = "studio-id";
+
+        public string EnvironmentValue { get; init; } = "test";
+
+        public string NodeId => NodeIdValue;
+
+        public string StudioId => StudioIdValue;
+
+        public string Environment => EnvironmentValue;
+
+        public TenantId TenantId => tenantId;
+
+        public string? ProjectId => null;
+
+        public CancellationToken Cancellation => CancellationToken.None;
+
+        public IReadOnlyDictionary<string, string> Baggage { get; } = new Dictionary<string, string>();
+
+        public DateTimeOffset CreatedAtUtc { get; } = DateTimeOffset.UtcNow;
+
+        public void AddBaggage(string key, string value)
+        {
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public Dictionary<string, object?>? ScopeState { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            ScopeState = state as Dictionary<string, object?>;
+            return NullDisposable.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public static readonly NullDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/docs/Abstractions.md
+++ b/HoneyDrunk.Web.Rest/docs/Abstractions.md
@@ -703,7 +703,7 @@ public static class RestTelemetryTags
 
 Standard tag names for logging and tracing. Use these for consistent telemetry across services.
 
-> **Note:** The library's `RequestLoggingScopeMiddleware` sets: `CorrelationId`, `HttpMethod`, `HttpPath`, `RequestId`, and `TenantId` (when Kernel context is available). Other tags are standardized names provided for consistency across services.
+> **Note:** The library's `RequestLoggingScopeMiddleware` sets: `CorrelationId`, `HttpMethod`, `HttpPath`, `RequestId`, and `TenantId` (when Kernel context is available and the request is non-Internal). Other tags are standardized names provided for consistency across services.
 
 #### Usage Example
 

--- a/HoneyDrunk.Web.Rest/docs/Middleware.md
+++ b/HoneyDrunk.Web.Rest/docs/Middleware.md
@@ -307,7 +307,7 @@ Enriches the logging scope with correlation ID, request metadata, and Kernel con
 | `TraceId` | `Activity.Current?.Id` | OpenTelemetry trace ID |
 | `OperationId` | `IOperationContext` | Kernel operation ID (if available) |
 | `OperationName` | `IOperationContext` | Kernel operation name (if available) |
-| `TenantId` | `IOperationContext` | Tenant ID (if available) |
+| `TenantId` | `IOperationContext` | Tenant ID (non-Internal requests only) |
 | `NodeId` | `IGridContext` | Grid node ID (if available) |
 | `StudioId` | `IGridContext` | Studio ID (if available) |
 | `Environment` | `IGridContext` | Environment name (if available) |
@@ -342,7 +342,7 @@ public class OrderService
         // - CorrelationId: "corr-456"
         // - HttpMethod: "POST"
         // - HttpPath: "/api/orders"
-        // - TenantId: "tenant-789" (if Kernel registered)
+        // - TenantId: "01H..." (if Kernel registered and request is non-Internal)
         // - NodeId: "order-service" (if Kernel registered)
         // - OrderId: "abc-123"
     }
@@ -351,7 +351,7 @@ public class OrderService
 
 ### Structured Log Output
 
-Kernel-derived properties (`TenantId`, `NodeId`, etc.) appear only when `HoneyDrunk.Kernel` is registered and `IOperationContextAccessor` provides a current context.
+Kernel-derived properties (`TenantId`, `NodeId`, etc.) appear only when `HoneyDrunk.Kernel` is registered and `IOperationContextAccessor` provides a current context. `TenantId` appears only for non-Internal requests; Internal-tenant traffic is represented by the absence of the property.
 
 ```json
 {

--- a/HoneyDrunk.Web.Rest/docs/Middleware.md
+++ b/HoneyDrunk.Web.Rest/docs/Middleware.md
@@ -1,4 +1,4 @@
-﻿# 🔄 Middleware - Request Pipeline Components
+# 🔄 Middleware - Request Pipeline Components
 
 [← Back to File Guide](FILE_GUIDE.md)
 
@@ -363,7 +363,7 @@ Kernel-derived properties (`TenantId`, `NodeId`, etc.) appear only when `HoneyDr
     "CorrelationId": "corr-456",
     "HttpMethod": "POST",
     "HttpPath": "/api/orders",
-    "TenantId": "tenant-789",
+    "TenantId": "01HZ6Y7K2V4P8Q9R0S1T2U3V4W",
     "NodeId": "order-service"
   }
 }


### PR DESCRIPTION
## Summary

- Adapts `RequestLoggingScopeMiddleware` to Kernel 0.5.0 typed `IOperationContext.TenantId`.
- Omits the `TenantId` log-scope entry for Internal-tenant requests; emits the sanitized ULID string for non-Internal requests.
- Leaves `ProjectId` behavior unchanged and preserves `HoneyDrunk.Web.Rest.Abstractions` public API surface.
- Bumps solution project versions to 0.4.0 and moves Kernel.Abstractions / Transport references to 0.5.0 without moving Auth/Vault/Standards.

Closes #13

Packet: `generated/issue-packets/active/adr-0026-grid-multi-tenant-primitives/01c-web-rest-request-logging-scope-typed-adoption.md`

## Validation

- `dotnet restore .\HoneyDrunk.Web.Rest.slnx` fails locally because the private HoneyDrunk Azure Artifacts feed returns 401.
- `dotnet restore .\HoneyDrunk.Web.Rest.slnx --ignore-failed-sources` initially fails until `HoneyDrunk.Transport` 0.5.0 is available; I validated against a locally packed `HoneyDrunk.Transport.0.5.0` from the sibling Transport ADR-0026 branch.
- `dotnet build .\HoneyDrunk.Web.Rest.slnx --no-restore` passes with NU1900 private-feed vulnerability warnings.
- `dotnet test .\HoneyDrunk.Web.Rest.slnx --no-build --logger "console;verbosity=minimal"` passes: Web.Rest.Tests 189/189, Web.Rest.Canary 27/27.

## Blockers / Notes

- CI may not restore/build until `HoneyDrunk.Transport` 0.5.0 is published to a feed CI can access.
- NU1900 private-feed vulnerability warning is non-fatal.
