### PR TITLE
chore: require Kernel context in Web.Rest

### DIFF
--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+
+- `AddRest()` now requires Kernel request context services from `AddHoneyDrunkNode()` before Web.Rest is registered.
+- `CorrelationMiddleware` now requires a live Kernel `IOperationContext` and uses its `CorrelationId`; it no longer falls back to request headers or generated IDs without Kernel context.
+- Consolidated duplicated `ApiResult` / `ApiResult<T>` failure factory construction while preserving public factory APIs and response shape.
+- Updated `HoneyDrunk.Kernel.Abstractions` from 0.5.0 to 0.7.0, `HoneyDrunk.Auth.AspNetCore` from 0.3.0 to 0.4.0, `HoneyDrunk.Transport` from 0.5.0 to 0.6.0, and Vault integration packages from 0.3.0 to 0.5.0.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed
@@ -62,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RestOptions` for configurable middleware behavior
 - Fluent `AddHoneyDrunkWebRest()` service registration with Kernel and Auth integration
 
+[0.5.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.5.0
 [0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to HoneyDrunk.Web.Rest.Abstractions will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Consolidated `ApiResult` and `ApiResult<T>` failure factory construction while preserving public factory method signatures and serialized response contracts.
+
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.4.0
+- No API surface changes
+
 ## [0.3.0] - 2026-04-25
 
 ### Changed
@@ -52,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All types are immutable records for thread safety
 - JSON serialization attributes included for consistent output
 
+[0.5.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.5.0
+[0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.1.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.Abstractions</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Pure contracts and constants for HoneyDrunk REST services. Provides standardized response envelopes (ApiResult, ApiErrorResponse), pagination contracts (PageRequest, PageResult), error codes, and telemetry tags. Zero runtime dependencies - can be used in any .NET project.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.4.0. No API changes.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Consolidated API result failure factories while preserving response contracts.</PackageReleaseNotes>
     <PackageTags>rest;api;contracts;response;envelope;error;pagination;validation;constants;abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResult.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResult.cs
@@ -63,12 +63,7 @@ public record ApiResult
     public static ApiResult Fail(
         string message,
         string code = ApiErrorCode.GeneralError,
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Failed,
-            Error = new ApiError { Code = code, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => Failure(ApiResultStatus.Failed, code, message, correlationId);
 
     /// <summary>
     /// Creates a not found <see cref="ApiResult"/>.
@@ -78,12 +73,7 @@ public record ApiResult
     /// <returns>A not found result.</returns>
     public static ApiResult NotFound(
         string message = "The requested resource was not found.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.NotFound,
-            Error = new ApiError { Code = ApiErrorCode.NotFound, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => Failure(ApiResultStatus.NotFound, ApiErrorCode.NotFound, message, correlationId);
 
     /// <summary>
     /// Creates an unauthorized <see cref="ApiResult"/>.
@@ -93,12 +83,7 @@ public record ApiResult
     /// <returns>An unauthorized result.</returns>
     public static ApiResult Unauthorized(
         string message = "Authentication is required.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Unauthorized,
-            Error = new ApiError { Code = ApiErrorCode.Unauthorized, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => Failure(ApiResultStatus.Unauthorized, ApiErrorCode.Unauthorized, message, correlationId);
 
     /// <summary>
     /// Creates a forbidden <see cref="ApiResult"/>.
@@ -108,12 +93,7 @@ public record ApiResult
     /// <returns>A forbidden result.</returns>
     public static ApiResult Forbidden(
         string message = "You do not have permission to access this resource.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Forbidden,
-            Error = new ApiError { Code = ApiErrorCode.Forbidden, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => Failure(ApiResultStatus.Forbidden, ApiErrorCode.Forbidden, message, correlationId);
 
     /// <summary>
     /// Creates a conflict <see cref="ApiResult"/>.
@@ -123,12 +103,7 @@ public record ApiResult
     /// <returns>A conflict result.</returns>
     public static ApiResult Conflict(
         string message,
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Conflict,
-            Error = new ApiError { Code = ApiErrorCode.Conflict, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => Failure(ApiResultStatus.Conflict, ApiErrorCode.Conflict, message, correlationId);
 
     /// <summary>
     /// Creates an error <see cref="ApiResult"/>.
@@ -138,10 +113,12 @@ public record ApiResult
     /// <returns>An error result.</returns>
     public static ApiResult InternalError(
         string message = "An internal server error occurred.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Error,
-            Error = new ApiError { Code = ApiErrorCode.InternalError, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => Failure(ApiResultStatus.Error, ApiErrorCode.InternalError, message, correlationId);
+
+    private static ApiResult Failure(ApiResultStatus status, string code, string message, string? correlationId) => new()
+    {
+        Status = status,
+        Error = new ApiError { Code = code, Message = message },
+        CorrelationId = correlationId,
+    };
 }

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResultOfT.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Results/ApiResultOfT.cs
@@ -40,12 +40,7 @@ public record ApiResult<T> : ApiResult
     public static new ApiResult<T> Fail(
         string message,
         string code = ApiErrorCode.GeneralError,
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Failed,
-            Error = new ApiError { Code = code, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => FromResult(ApiResult.Fail(message, code, correlationId));
 
     /// <summary>
     /// Creates a not found <see cref="ApiResult{T}"/>.
@@ -55,12 +50,7 @@ public record ApiResult<T> : ApiResult
     /// <returns>A not found result.</returns>
     public static new ApiResult<T> NotFound(
         string message = "The requested resource was not found.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.NotFound,
-            Error = new ApiError { Code = ApiErrorCode.NotFound, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => FromResult(ApiResult.NotFound(message, correlationId));
 
     /// <summary>
     /// Creates an unauthorized <see cref="ApiResult{T}"/>.
@@ -70,12 +60,7 @@ public record ApiResult<T> : ApiResult
     /// <returns>An unauthorized result.</returns>
     public static new ApiResult<T> Unauthorized(
         string message = "Authentication is required.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Unauthorized,
-            Error = new ApiError { Code = ApiErrorCode.Unauthorized, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => FromResult(ApiResult.Unauthorized(message, correlationId));
 
     /// <summary>
     /// Creates a forbidden <see cref="ApiResult{T}"/>.
@@ -85,12 +70,7 @@ public record ApiResult<T> : ApiResult
     /// <returns>A forbidden result.</returns>
     public static new ApiResult<T> Forbidden(
         string message = "You do not have permission to access this resource.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Forbidden,
-            Error = new ApiError { Code = ApiErrorCode.Forbidden, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => FromResult(ApiResult.Forbidden(message, correlationId));
 
     /// <summary>
     /// Creates a conflict <see cref="ApiResult{T}"/>.
@@ -100,12 +80,7 @@ public record ApiResult<T> : ApiResult
     /// <returns>A conflict result.</returns>
     public static new ApiResult<T> Conflict(
         string message,
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Conflict,
-            Error = new ApiError { Code = ApiErrorCode.Conflict, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => FromResult(ApiResult.Conflict(message, correlationId));
 
     /// <summary>
     /// Creates an error <see cref="ApiResult{T}"/>.
@@ -115,12 +90,7 @@ public record ApiResult<T> : ApiResult
     /// <returns>An error result.</returns>
     public static new ApiResult<T> InternalError(
         string message = "An internal server error occurred.",
-        string? correlationId = null) => new()
-        {
-            Status = ApiResultStatus.Error,
-            Error = new ApiError { Code = ApiErrorCode.InternalError, Message = message },
-            CorrelationId = correlationId,
-        };
+        string? correlationId = null) => FromResult(ApiResult.InternalError(message, correlationId));
 
     /// <summary>
     /// Converts from a non-generic <see cref="ApiResult"/> to a generic <see cref="ApiResult{T}"/>.

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to HoneyDrunk.Web.Rest.AspNetCore will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+
+#### Middleware
+- `CorrelationMiddleware` now requires a live Kernel `IOperationContext` for each request and uses `IOperationContext.CorrelationId` as the only correlation source.
+- Incoming correlation headers are still compared to Kernel context for mismatch warnings, but Web.Rest no longer falls back to headers or generated IDs when Kernel context is missing.
+
+#### Dependency Injection
+- `AddRest()` now fails fast unless Kernel request context services have already been registered via `AddHoneyDrunkNode()`.
+- Applications must place `UseGridContext()` before `UseRest()` so Web.Rest sees a live request operation context.
+
+#### Dependencies
+- Bumped `HoneyDrunk.Kernel.Abstractions` from 0.5.0 to 0.7.0.
+- Bumped `HoneyDrunk.Auth.AspNetCore` from 0.3.0 to 0.4.0.
+- Bumped `HoneyDrunk.Transport` from 0.5.0 to 0.6.0.
+- Bumped `HoneyDrunk.Vault.EventGrid`, `HoneyDrunk.Vault.Providers.AppConfiguration`, and `HoneyDrunk.Vault.Providers.AzureKeyVault` from 0.3.0 to 0.5.0.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed
@@ -74,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `IncludeExceptionDetails` - Stack traces in errors (default: false)
   - `IncludeTraceId` - OpenTelemetry trace ID in responses (default: true)
   - `ReturnCorrelationIdInResponseHeader` - Echo correlation ID back (default: true)
-  - `GenerateCorrelationIdIfMissing` - Auto-generate if not provided (default: true)
+  - `GenerateCorrelationIdIfMissing` - Legacy option retained for compatibility (default: true)
   - `EnableRequestLoggingScope` - Logging scope enrichment (default: true)
   - `EnableExceptionMapping` - Exception-to-error mapping (default: true)
   - `EnableModelStateValidationFilter` - MVC validation filter (default: true)
@@ -82,17 +100,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `EnableAuthFailureShaping` - Shape 401/403 as ApiErrorResponse (default: true)
 
 #### Middleware
-- `CorrelationMiddleware` - Extracts/generates correlation ID with priority:
-  1. Kernel `IOperationContext.CorrelationId` (if `IOperationContextAccessor` is registered)
-  2. Incoming `X-Correlation-Id` header
-  3. Generated GUID
+- `CorrelationMiddleware` - Requires live Kernel `IOperationContext.CorrelationId`; incoming `X-Correlation-Id` is compared for mismatch warnings only.
 - `ExceptionMappingMiddleware` - Catches unhandled exceptions, maps to `ApiErrorResponse` with appropriate HTTP status codes
 - `RequestLoggingScopeMiddleware` - Enriches logging scope with:
   - Correlation ID, HTTP method, path, request ID, trace ID
   - Kernel context (if available): OperationId, OperationName, CausationId, TenantId, ProjectId, NodeId, StudioId, Environment
 
 #### Kernel Integration
-- Uses `HoneyDrunk.Kernel.Abstractions.Context.IOperationContextAccessor` when registered
+- Requires `HoneyDrunk.Kernel.Abstractions.Context.IOperationContextAccessor` and a live current operation context
 - Prefers `IOperationContext.CorrelationId` over request headers
 - Enriches logging scope with `IGridContext` values (NodeId, StudioId, Environment)
 
@@ -153,9 +168,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Model state validation filter suppresses default ASP.NET Core validation behavior
 - JSON defaults are automatically applied to MVC JsonOptions
 - All middleware respects configuration toggles
-- Kernel/Auth/Transport integrations are optional - middleware gracefully degrades when not registered
+- Kernel request context is required for Web.Rest correlation; Auth and Transport integrations remain optional.
 - Auth failure shaping uses `IAuthorizationMiddlewareResultHandler` for scheme-agnostic 401/403 handling
 
+[0.5.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.5.0
 [0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/releases/tag/v0.2.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
 using HoneyDrunk.Web.Rest.AspNetCore.Auth;
 using HoneyDrunk.Web.Rest.AspNetCore.Configuration;
 using HoneyDrunk.Web.Rest.AspNetCore.Context;
@@ -26,6 +27,7 @@ public static class ServiceCollectionExtensions
         Action<RestOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);
+        EnsureKernelRequestContextRegistered(services);
 
         services.TryAddSingleton<ICorrelationIdAccessor, CorrelationIdAccessor>();
 
@@ -68,5 +70,17 @@ public static class ServiceCollectionExtensions
         }
 
         return services;
+    }
+
+    private static void EnsureKernelRequestContextRegistered(IServiceCollection services)
+    {
+        if (services.Any(static descriptor => descriptor.ServiceType == typeof(IOperationContextAccessor)))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "AddRest() requires HoneyDrunk.Kernel request context services. "
+            + "Call AddHoneyDrunkNode() before AddRest(), then place UseGridContext() before UseRest() in the request pipeline.");
     }
 }

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Web.Rest.AspNetCore</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>ASP.NET Core integration for HoneyDrunk REST conventions. Provides middleware for correlation propagation, exception mapping, and request logging. Includes MVC filters for model validation, minimal API endpoint conventions, and JSON serialization defaults. Ensures consistent API responses across all services.</Description>
-    <PackageReleaseNotes>v0.4.0: Adopted Kernel 0.5.0 typed TenantId in request logging scopes and omitted TenantId for Internal-tenant requests.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Requires live Kernel request context for correlation and consolidates API result failure factories.</PackageReleaseNotes>
     <PackageTags>rest;api;aspnetcore;middleware;correlation;exception;validation;filter;json;conventions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -29,17 +29,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.3.0" />
+    <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.4.0" />
 
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Transport" Version="0.5.0" />
-    <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.3.0" />
-    <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.3.0" />
-    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.3.0" />
+    <PackageReference Include="HoneyDrunk.Transport" Version="0.6.0" />
+    <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/CorrelationMiddleware.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/CorrelationMiddleware.cs
@@ -4,17 +4,15 @@ using HoneyDrunk.Web.Rest.AspNetCore.Configuration;
 using HoneyDrunk.Web.Rest.AspNetCore.Context;
 using HoneyDrunk.Web.Rest.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Diagnostics;
 
 namespace HoneyDrunk.Web.Rest.AspNetCore.Middleware;
 
 /// <summary>
 /// Middleware that handles correlation ID propagation.
-/// Reads the correlation ID from the incoming request header or Kernel operation context,
-/// generates one if missing, and returns it in the response header.
+/// Requires a live Kernel operation context, mirrors its correlation ID into Web.Rest accessors,
+/// and returns it in the response header.
 /// </summary>
 /// <remarks>
 /// Initializes a new instance of the <see cref="CorrelationMiddleware"/> class.
@@ -32,15 +30,14 @@ public sealed class CorrelationMiddleware(RequestDelegate next, IOptions<RestOpt
     /// </summary>
     /// <param name="context">The HTTP context.</param>
     /// <param name="correlationIdAccessor">The correlation ID accessor.</param>
+    /// <param name="operationContextAccessor">The Kernel operation context accessor.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task InvokeAsync(
         HttpContext context,
-        ICorrelationIdAccessor correlationIdAccessor)
+        ICorrelationIdAccessor correlationIdAccessor,
+        IOperationContextAccessor operationContextAccessor)
     {
-        // Try to get Kernel operation context accessor if available
-        IOperationContextAccessor? operationContextAccessor = context.RequestServices.GetService<IOperationContextAccessor>();
-
-        string correlationId = GetOrCreateCorrelationId(context, operationContextAccessor);
+        string correlationId = GetCorrelationId(context, operationContextAccessor);
 
         correlationIdAccessor.SetCorrelationId(correlationId);
 
@@ -63,18 +60,17 @@ public sealed class CorrelationMiddleware(RequestDelegate next, IOptions<RestOpt
         await _next(context).ConfigureAwait(false);
     }
 
-    private string GetOrCreateCorrelationId(HttpContext context, IOperationContextAccessor? operationContextAccessor)
+    private string GetCorrelationId(HttpContext context, IOperationContextAccessor operationContextAccessor)
     {
-        string? kernelCorrelationId = null;
+        IOperationContext operationContext = operationContextAccessor.Current
+            ?? throw new InvalidOperationException(
+                "HoneyDrunk.Web.Rest requires a live Kernel IOperationContext for each request. "
+                + "Register HoneyDrunk.Kernel with AddHoneyDrunkNode() and place UseGridContext() before UseRest().");
 
-        // Priority 1: Kernel operation context (if available and has a correlation ID)
-        if (operationContextAccessor?.Current is { } operationContext &&
-            !string.IsNullOrWhiteSpace(operationContext.CorrelationId))
-        {
-            kernelCorrelationId = operationContext.CorrelationId;
-        }
+        string kernelCorrelationId = !string.IsNullOrWhiteSpace(operationContext.CorrelationId)
+            ? operationContext.CorrelationId
+            : throw new InvalidOperationException("HoneyDrunk.Web.Rest requires Kernel IOperationContext.CorrelationId to be populated.");
 
-        // Check for incoming request header
         string? headerCorrelationId = null;
         if (context.Request.Headers.TryGetValue(_options.CorrelationIdHeaderName, out Microsoft.Extensions.Primitives.StringValues headerValue)
             && !string.IsNullOrWhiteSpace(headerValue.ToString()))
@@ -82,8 +78,7 @@ public sealed class CorrelationMiddleware(RequestDelegate next, IOptions<RestOpt
             headerCorrelationId = headerValue.ToString();
         }
 
-        // Log warning if both exist and differ
-        if (kernelCorrelationId is not null && headerCorrelationId is not null
+        if (headerCorrelationId is not null
             && !string.Equals(kernelCorrelationId, headerCorrelationId, StringComparison.Ordinal))
         {
             logger.LogWarning(
@@ -95,24 +90,6 @@ public sealed class CorrelationMiddleware(RequestDelegate next, IOptions<RestOpt
                 LogValueSanitizer.Sanitize(context.Request.Path.Value));
         }
 
-        // Priority 1: Kernel wins
-        if (kernelCorrelationId is not null)
-        {
-            return kernelCorrelationId;
-        }
-
-        // Priority 2: Incoming request header
-        if (headerCorrelationId is not null)
-        {
-            return headerCorrelationId;
-        }
-
-        // Priority 3: Generate a new one if allowed
-        if (!_options.GenerateCorrelationIdIfMissing)
-        {
-            return string.Empty;
-        }
-
-        return Activity.Current?.Id ?? Guid.NewGuid().ToString("N");
+        return kernelCorrelationId;
     }
 }

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/README.md
@@ -7,6 +7,13 @@ Middleware, filters, and endpoint helpers that enforce HoneyDrunk REST conventio
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
+// Add Kernel first so Web.Rest can require a live request context
+builder.Services.AddHoneyDrunkNode(options =>
+{
+    options.NodeId = new("my-node");
+    // Configure the remaining node identity options here.
+});
+
 // Add REST services
 builder.Services.AddRest(options =>
 {
@@ -16,7 +23,8 @@ builder.Services.AddRest(options =>
 
 var app = builder.Build();
 
-// Use REST middleware (call early, before routing)
+// Establish Kernel request context before REST middleware
+app.UseGridContext();
 app.UseRest();
 
 app.UseRouting();
@@ -54,17 +62,17 @@ app.MapHoneyDrunkWebRestVaultInvalidationWebhook();
 
 ### Correlation ID Propagation
 
-- Prefers Kernel `IOperationContext.CorrelationId` if available (via `IOperationContextAccessor`)
-- Falls back to `X-Correlation-Id` header from incoming requests
-- Generates a new correlation ID if not present
-- Returns correlation ID in response headers
-- Makes correlation ID available via `ICorrelationIdAccessor`
-- Logs a warning when both Kernel and header correlation IDs are present but differ
+- Requires Kernel `IOperationContext.CorrelationId` from a live request context
+- Returns the Kernel correlation ID in response headers
+- Makes the Kernel correlation ID available via `ICorrelationIdAccessor`
+- Logs a warning when incoming `X-Correlation-Id` differs from Kernel context
 
 ### Kernel Integration
 
-When `HoneyDrunk.Kernel` is registered, the middleware automatically:
-- Uses `IOperationContextAccessor.Current.CorrelationId` as the preferred correlation source
+Web.Rest requires `HoneyDrunk.Kernel` request context:
+- Call `AddHoneyDrunkNode()` before `AddRest()`
+- Call `UseGridContext()` before `UseRest()`
+- Uses `IOperationContextAccessor.Current.CorrelationId` as the correlation source
 - Enriches logging scopes with Kernel context values:
   - `OperationId`, `OperationName`, `CausationId`
   - `TenantId`, `ProjectId`
@@ -152,7 +160,7 @@ app.MapDelete("/api/items/{id}", DeleteItemAsync)
 | IncludeExceptionDetails | false | Include exception details in errors |
 | IncludeTraceId | true | Include trace ID in responses |
 | ReturnCorrelationIdInResponseHeader | true | Return correlation ID in headers |
-| GenerateCorrelationIdIfMissing | true | Generate ID if not in request |
+| GenerateCorrelationIdIfMissing | true | Legacy option; Web.Rest correlation now comes from Kernel request context |
 | EnableRequestLoggingScope | true | Enable logging scope middleware |
 | EnableExceptionMapping | true | Enable exception mapping middleware |
 | EnableModelStateValidationFilter | true | Enable model validation filter |
@@ -162,10 +170,10 @@ app.MapDelete("/api/items/{id}", DeleteItemAsync)
 ## Dependencies
 
 - HoneyDrunk.Web.Rest.Abstractions (contracts)
-- HoneyDrunk.Kernel.Abstractions 0.5.0 (optional, for Grid context and typed exceptions)
-- HoneyDrunk.Auth.AspNetCore 0.3.0 (optional, for identity context)
-- HoneyDrunk.Transport 0.5.0 (optional, for envelope mapping)
-- HoneyDrunk.Vault.EventGrid 0.3.0 (for cache invalidation webhook mapping)
-- HoneyDrunk.Vault.Providers.AppConfiguration 0.3.0 (for env-var-driven App Configuration bootstrap)
-- HoneyDrunk.Vault.Providers.AzureKeyVault 0.3.0 (for env-var-driven Key Vault bootstrap)
+- HoneyDrunk.Kernel.Abstractions 0.7.0 (required, for request context and typed exceptions)
+- HoneyDrunk.Auth.AspNetCore 0.4.0 (optional, for identity context)
+- HoneyDrunk.Transport 0.6.0 (optional, for envelope mapping)
+- HoneyDrunk.Vault.EventGrid 0.5.0 (for cache invalidation webhook mapping)
+- HoneyDrunk.Vault.Providers.AppConfiguration 0.5.0 (for env-var-driven App Configuration bootstrap)
+- HoneyDrunk.Vault.Providers.AzureKeyVault 0.5.0 (for env-var-driven Key Vault bootstrap)
 - Microsoft.AspNetCore.App (framework reference)

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
@@ -68,6 +68,9 @@ internal sealed class CanaryHostFactory : IDisposable
                 webBuilder.UseTestServer();
                 webBuilder.ConfigureServices(services =>
                 {
+                    IOperationContextAccessor operationContextAccessor = OperationContextAccessor ?? new FakeOperationContextAccessor();
+                    services.AddSingleton(operationContextAccessor);
+
                     services.AddRest(options =>
                     {
                         options.IncludeExceptionDetails = false;
@@ -82,12 +85,6 @@ internal sealed class CanaryHostFactory : IDisposable
                     });
 
                     services.AddRouting();
-
-                    // Register fake operation context accessor if provided
-                    if (OperationContextAccessor is not null)
-                    {
-                        services.AddSingleton(OperationContextAccessor);
-                    }
 
                     // Auth setup
                     if (UseAuthWithoutIdentityAccessor)
@@ -111,6 +108,29 @@ internal sealed class CanaryHostFactory : IDisposable
 
                 webBuilder.Configure(app =>
                 {
+                    app.Use(async (context, next) =>
+                    {
+                        IOperationContextAccessor accessor = context.RequestServices.GetRequiredService<IOperationContextAccessor>();
+                        bool createdContext = accessor.Current is null;
+
+                        if (createdContext)
+                        {
+                            string correlationId = context.Request.Headers.TryGetValue("X-Correlation-Id", out Microsoft.Extensions.Primitives.StringValues headerValue)
+                                && !string.IsNullOrWhiteSpace(headerValue.ToString())
+                                ? headerValue.ToString()
+                                : Guid.NewGuid().ToString("N");
+
+                            accessor.Current = new StubOperationContext(correlationId);
+                        }
+
+                        await next(context).ConfigureAwait(false);
+
+                        if (createdContext)
+                        {
+                            accessor.Current = null;
+                        }
+                    });
+
                     app.UseRest();
                     app.UseRouting();
 

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/CanaryHostFactory.cs
@@ -123,11 +123,16 @@ internal sealed class CanaryHostFactory : IDisposable
                             accessor.Current = new StubOperationContext(correlationId);
                         }
 
-                        await next(context).ConfigureAwait(false);
-
-                        if (createdContext)
+                        try
                         {
-                            accessor.Current = null;
+                            await next(context).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            if (createdContext)
+                            {
+                                accessor.Current = null;
+                            }
                         }
                     });
 

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubGridContext.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubGridContext.cs
@@ -8,13 +8,13 @@ namespace HoneyDrunk.Web.Rest.Canary;
 /// Used by <see cref="StubOperationContext"/> to satisfy RequestLoggingScopeMiddleware
 /// which accesses GridContext properties for telemetry enrichment.
 /// </summary>
-internal sealed class StubGridContext : IGridContext
+internal sealed class StubGridContext(string correlationId = "canary-stub-correlation") : IGridContext
 {
     /// <inheritdoc/>
     public bool IsInitialized => true;
 
     /// <inheritdoc/>
-    public string CorrelationId => string.Empty;
+    public string CorrelationId => correlationId;
 
     /// <inheritdoc/>
     public string? CausationId => null;

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubOperationContext.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/StubOperationContext.cs
@@ -10,7 +10,7 @@ namespace HoneyDrunk.Web.Rest.Canary;
 internal sealed class StubOperationContext(string correlationId) : IOperationContext
 {
     /// <inheritdoc/>
-    public IGridContext GridContext { get; } = new StubGridContext();
+    public IGridContext GridContext { get; } = new StubGridContext(correlationId);
 
     /// <inheritdoc/>
     public string OperationName => "canary-stub";

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/CorrelationMiddlewareTests.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/CorrelationMiddlewareTests.cs
@@ -1,0 +1,44 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Configuration;
+using HoneyDrunk.Web.Rest.AspNetCore.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace HoneyDrunk.Web.Rest.Tests.AspNetCore;
+
+/// <summary>
+/// Tests for Kernel-backed correlation middleware behavior.
+/// </summary>
+public sealed class CorrelationMiddlewareTests
+{
+    /// <summary>
+    /// Verifies that correlation middleware fails fast when Kernel did not establish an operation context.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InvokeAsync_WithoutCurrentOperationContext_Throws()
+    {
+        CorrelationMiddleware middleware = new(
+            _ => Task.CompletedTask,
+            Options.Create(new RestOptions()),
+            NullLogger<CorrelationMiddleware>.Instance);
+
+        InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() =>
+            middleware.InvokeAsync(
+                new DefaultHttpContext(),
+                new CorrelationIdAccessor(),
+                new TestOperationContextAccessor()))
+;
+
+        exception.Message.ShouldContain("live Kernel IOperationContext");
+        exception.Message.ShouldContain("UseGridContext()");
+    }
+
+    private sealed class TestOperationContextAccessor : IOperationContextAccessor
+    {
+        public IOperationContext? Current { get; set; }
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,47 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace HoneyDrunk.Web.Rest.Tests.AspNetCore;
+
+/// <summary>
+/// Tests for REST service registration requirements.
+/// </summary>
+public sealed class ServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that AddRest fails fast when Kernel request context services are missing.
+    /// </summary>
+    [Fact]
+    public void AddRest_WithoutKernelOperationContextAccessor_Throws()
+    {
+        ServiceCollection services = new();
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(() => services.AddRest());
+
+        exception.Message.ShouldContain("AddHoneyDrunkNode()");
+        exception.Message.ShouldContain("UseGridContext()");
+    }
+
+    /// <summary>
+    /// Verifies that AddRest registers Web.Rest services when Kernel request context services are present.
+    /// </summary>
+    [Fact]
+    public void AddRest_WithKernelOperationContextAccessor_RegistersRestServices()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IOperationContextAccessor>(new TestOperationContextAccessor());
+
+        services.AddRest();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ICorrelationIdAccessor>().ShouldNotBeNull();
+    }
+
+    private sealed class TestOperationContextAccessor : IOperationContextAccessor
+    {
+        public IOperationContext? Current { get; set; }
+    }
+}

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/TestHost/TestApiFactory.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/TestHost/TestApiFactory.cs
@@ -72,8 +72,15 @@ public sealed class TestApiFactory : IDisposable
                             : Guid.NewGuid().ToString("N");
 
                         accessor.Current = new TestOperationContext(correlationId);
-                        await next(context).ConfigureAwait(false);
-                        accessor.Current = null;
+
+                        try
+                        {
+                            await next(context).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            accessor.Current = null;
+                        }
                     });
 
                     app.UseRest();

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/TestHost/TestApiFactory.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/TestHost/TestApiFactory.cs
@@ -1,3 +1,5 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Web.Rest.AspNetCore.Extensions;
 using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
 using Microsoft.AspNetCore.Builder;
@@ -39,6 +41,8 @@ public sealed class TestApiFactory : IDisposable
                 webBuilder.UseTestServer();
                 webBuilder.ConfigureServices(services =>
                 {
+                    services.AddSingleton<IOperationContextAccessor>(new TestOperationContextAccessor());
+
                     services.AddRest(options =>
                     {
                         options.IncludeExceptionDetails = IncludeExceptionDetails;
@@ -59,6 +63,19 @@ public sealed class TestApiFactory : IDisposable
 
                 webBuilder.Configure(app =>
                 {
+                    app.Use(async (context, next) =>
+                    {
+                        IOperationContextAccessor accessor = context.RequestServices.GetRequiredService<IOperationContextAccessor>();
+                        string correlationId = context.Request.Headers.TryGetValue("X-Correlation-Id", out Microsoft.Extensions.Primitives.StringValues headerValue)
+                            && !string.IsNullOrWhiteSpace(headerValue.ToString())
+                            ? headerValue.ToString()
+                            : Guid.NewGuid().ToString("N");
+
+                        accessor.Current = new TestOperationContext(correlationId);
+                        await next(context).ConfigureAwait(false);
+                        accessor.Current = null;
+                    });
+
                     app.UseRest();
                     app.UseRouting();
 
@@ -80,5 +97,82 @@ public sealed class TestApiFactory : IDisposable
     {
         _client?.Dispose();
         _host?.Dispose();
+    }
+
+    private sealed class TestOperationContextAccessor : IOperationContextAccessor
+    {
+        public IOperationContext? Current { get; set; }
+    }
+
+    private sealed class TestOperationContext(string correlationId) : IOperationContext
+    {
+        public IGridContext GridContext { get; } = new TestGridContext(correlationId);
+
+        public string OperationName => "test-request";
+
+        public string OperationId => "test-operation-id";
+
+        public string CorrelationId => GridContext.CorrelationId;
+
+        public string? CausationId => null;
+
+        public TenantId TenantId => TenantId.Internal;
+
+        public string? ProjectId => null;
+
+        public DateTimeOffset StartedAtUtc { get; } = DateTimeOffset.UtcNow;
+
+        public DateTimeOffset? CompletedAtUtc => null;
+
+        public bool? IsSuccess => null;
+
+        public string? ErrorMessage => null;
+
+        public IReadOnlyDictionary<string, object?> Metadata { get; } = new Dictionary<string, object?>();
+
+        public void Complete()
+        {
+        }
+
+        public void Fail(string errorMessage, Exception? exception = null)
+        {
+        }
+
+        public void AddMetadata(string key, object? value)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestGridContext(string correlationId) : IGridContext
+    {
+        public bool IsInitialized => true;
+
+        public string CorrelationId => correlationId;
+
+        public string? CausationId => null;
+
+        public string NodeId => "test-node";
+
+        public string StudioId => "test-studio";
+
+        public string Environment => "test";
+
+        public TenantId TenantId => TenantId.Internal;
+
+        public string? ProjectId => null;
+
+        public CancellationToken Cancellation => CancellationToken.None;
+
+        public IReadOnlyDictionary<string, string> Baggage { get; } = new Dictionary<string, string>();
+
+        public DateTimeOffset CreatedAtUtc { get; } = DateTimeOffset.UtcNow;
+
+        public void AddBaggage(string key, string value)
+        {
+        }
     }
 }

--- a/HoneyDrunk.Web.Rest/docs/Architecture.md
+++ b/HoneyDrunk.Web.Rest/docs/Architecture.md
@@ -1,4 +1,4 @@
-﻿# 🏛️ Architecture - Layer Responsibilities and Design
+# 🏛️ Architecture - Layer Responsibilities and Design
 
 [← Back to File Guide](FILE_GUIDE.md)
 
@@ -106,7 +106,9 @@ public class OrderResponse
 
 ```csharp
 // Requires ASP.NET Core
+builder.Services.AddHoneyDrunkNode(options => { /* node identity */ });
 builder.Services.AddRest();
+app.UseGridContext();
 app.UseRest();
 ```
 
@@ -165,7 +167,7 @@ app.UseRest();
 2. **AspNetCore depends on Abstractions** - Uses contracts for implementation
 3. **Applications depend on AspNetCore** - For full functionality
 4. **Client libraries depend on Abstractions only** - For contract definitions
-5. **Kernel/Auth/Transport are optional** - Middleware gracefully degrades when not registered
+5. **Kernel request context is required** - Web.Rest requires Kernel request context for correlation; Auth and Transport integrations remain optional
 
 [↑ Back to top](#table-of-contents)
 
@@ -444,12 +446,11 @@ app.MapGet("/orders/{id}", (Guid id) =>
 .WithRest<Order>();
 ```
 
-### Pattern 5: With Kernel Integration
+### Pattern .: With Kernel Integration
 
 ```csharp
-// When HoneyDrunk.Kernel is registered, correlation prefers IOperationContext
-// Register Kernel services so IOperationContextAccessor is available
-builder.Services.AddSingleton<IOperationContextAccessor, OperationContextAccessor>();
+// When HoneyDrunk.Kernel request context is established, correlation prefers IOperationContext
+// Register Kernel services and middleware so IOperationContextAccessor has a live request context
 builder.Services.AddRest();
 
 // Middleware will:

--- a/HoneyDrunk.Web.Rest/docs/Architecture.md
+++ b/HoneyDrunk.Web.Rest/docs/Architecture.md
@@ -95,7 +95,7 @@ public class OrderResponse
 **Dependencies:** 
 - `HoneyDrunk.Web.Rest.Abstractions`
 - `Microsoft.AspNetCore.App` (framework reference)
-- `HoneyDrunk.Kernel.Abstractions` (optional, for Grid context)
+- `HoneyDrunk.Kernel.Abstractions` (required, for request context)
 - `HoneyDrunk.Auth.AspNetCore` (optional, for identity context)
 - `HoneyDrunk.Transport` (optional, uses `HoneyDrunk.Transport.Abstractions` namespace types for envelope mapping only)
 
@@ -433,11 +433,15 @@ app.Use(async (context, next) =>
 ### Pattern 4: Minimal API Only
 
 ```csharp
-// Skip MVC filter, use minimal APIs
+// Web.Rest still requires Kernel request context, even for minimal APIs.
+builder.Services.AddHoneyDrunkNode(options => { /* node identity */ });
 builder.Services.AddRest(options =>
 {
     options.EnableModelStateValidationFilter = false; // Not needed
 });
+
+app.UseGridContext();
+app.UseRest();
 
 app.MapGet("/orders/{id}", (Guid id) =>
 {
@@ -446,13 +450,17 @@ app.MapGet("/orders/{id}", (Guid id) =>
 .WithRest<Order>();
 ```
 
-### Pattern .: With Kernel Integration
+### Pattern 5: With Kernel Integration
 
 ```csharp
-// When HoneyDrunk.Kernel request context is established, correlation prefers IOperationContext
-// Register Kernel services and middleware so IOperationContextAccessor has a live request context
+// Web.Rest requires Kernel services and live request context.
+builder.Services.AddHoneyDrunkNode(options => { /* node identity */ });
 builder.Services.AddRest();
 
+app.UseGridContext();
+app.UseRest();
+
 // Middleware will:
-// 1. Use IOperationContext.CorrelationId if available
+// 1. Require IOperationContext.CorrelationId
 // 2. Enrich logging scope with Grid context values
+```

--- a/HoneyDrunk.Web.Rest/docs/Configuration.md
+++ b/HoneyDrunk.Web.Rest/docs/Configuration.md
@@ -57,7 +57,7 @@ Central configuration for all REST middleware and filters. Configure once during
 | Property | Default | Description |
 |----------|---------|-------------|
 | `CorrelationIdHeaderName` | `"X-Correlation-Id"` | HTTP header name for correlation ID |
-| `GenerateCorrelationIdIfMissing` | `true` | Generate new GUID if header not present |
+| `GenerateCorrelationIdIfMissing` | `true` | Legacy option; Web.Rest correlation now comes from Kernel request context |
 | `ReturnCorrelationIdInResponseHeader` | `true` | Include correlation ID in response headers |
 
 #### Error Handling Settings
@@ -84,9 +84,9 @@ Central configuration for all REST middleware and filters. Configure once during
 ```csharp
 builder.Services.AddRest(options =>
 {
-    // Correlation ID
+    // Correlation ID (sourced from Kernel request context)
     options.CorrelationIdHeaderName = "X-Correlation-Id";
-    options.GenerateCorrelationIdIfMissing = true;
+    options.GenerateCorrelationIdIfMissing = true; // Legacy option
     options.ReturnCorrelationIdInResponseHeader = true;
     
     // Error handling

--- a/HoneyDrunk.Web.Rest/docs/Configuration.md
+++ b/HoneyDrunk.Web.Rest/docs/Configuration.md
@@ -79,14 +79,17 @@ Central configuration for all REST middleware and filters. Configure once during
 
 ### Usage Examples
 
+All `AddRest()` examples assume Kernel services are registered first with `AddHoneyDrunkNode()`, and the request pipeline calls `UseGridContext()` before `UseRest()`.
+
 #### Full Configuration
 
 ```csharp
+builder.Services.AddHoneyDrunkNode(options => { /* node identity */ });
 builder.Services.AddRest(options =>
 {
-    // Correlation ID (sourced from Kernel request context)
+    // Correlation ID (required from Kernel request context)
     options.CorrelationIdHeaderName = "X-Correlation-Id";
-    options.GenerateCorrelationIdIfMissing = true; // Legacy option
+    options.GenerateCorrelationIdIfMissing = true; // Legacy option; Kernel supplies the value
     options.ReturnCorrelationIdInResponseHeader = true;
     
     // Error handling

--- a/HoneyDrunk.Web.Rest/docs/FILE_GUIDE.md
+++ b/HoneyDrunk.Web.Rest/docs/FILE_GUIDE.md
@@ -334,9 +334,9 @@ services.AddRest(options =>
     options.IncludeExceptionDetails = false;        // Stack traces in errors (dev only)
     options.IncludeTraceId = true;                  // OpenTelemetry trace ID
     
-    // Correlation ID
+    // Correlation ID (sourced from Kernel request context)
     options.CorrelationIdHeaderName = "X-Correlation-Id";
-    options.GenerateCorrelationIdIfMissing = true;
+    options.GenerateCorrelationIdIfMissing = true; // Legacy option
     options.ReturnCorrelationIdInResponseHeader = true;
     
     // JSON

--- a/HoneyDrunk.Web.Rest/docs/FILE_GUIDE.md
+++ b/HoneyDrunk.Web.Rest/docs/FILE_GUIDE.md
@@ -96,6 +96,9 @@ using HoneyDrunk.Web.Rest.AspNetCore.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Register Kernel first so Web.Rest has a live request context
+builder.Services.AddHoneyDrunkNode(options => { /* node identity */ });
+
 // Register REST services
 builder.Services.AddRest(options =>
 {
@@ -110,7 +113,8 @@ builder.Services.AddControllers();
 
 var app = builder.Build();
 
-// Add REST middleware early in the pipeline
+// Establish Kernel request context before REST middleware
+app.UseGridContext();
 app.UseRest();
 
 app.MapControllers();
@@ -334,9 +338,9 @@ services.AddRest(options =>
     options.IncludeExceptionDetails = false;        // Stack traces in errors (dev only)
     options.IncludeTraceId = true;                  // OpenTelemetry trace ID
     
-    // Correlation ID (sourced from Kernel request context)
+    // Correlation ID (required from Kernel request context)
     options.CorrelationIdHeaderName = "X-Correlation-Id";
-    options.GenerateCorrelationIdIfMissing = true; // Legacy option
+    options.GenerateCorrelationIdIfMissing = true; // Legacy option; Kernel supplies the value
     options.ReturnCorrelationIdInResponseHeader = true;
     
     // JSON
@@ -344,13 +348,13 @@ services.AddRest(options =>
 });
 ```
 
-### Optional Integrations
+### Integrations
 
-When registered, the middleware automatically uses:
+Web.Rest requires Kernel request context and can optionally use nearby Core integrations:
 
-- **HoneyDrunk.Kernel** - `IOperationContextAccessor` for correlation and logging enrichment
-- **HoneyDrunk.Auth.AspNetCore** - `IAuthenticatedIdentityAccessor` for context-aware auth errors
-- **HoneyDrunk.Transport** - `ITransportEnvelope.ToApiResult()` extension methods
+- **HoneyDrunk.Kernel** - required `IOperationContextAccessor` for correlation and logging enrichment
+- **HoneyDrunk.Auth.AspNetCore** - optional `IAuthenticatedIdentityAccessor` for context-aware auth errors
+- **HoneyDrunk.Transport** - optional `ITransportEnvelope.ToApiResult()` extension methods
 
 ---
 
@@ -361,7 +365,7 @@ When registered, the middleware automatically uses:
 - **System.Text.Json** - JSON serialization
 - **Microsoft.AspNetCore.*** - ASP.NET Core runtime (AspNetCore package only)
 - **Microsoft.Extensions.*** - DI, Logging, Configuration
-- **HoneyDrunk.Kernel.Abstractions** - Optional, for Grid context
+- **HoneyDrunk.Kernel.Abstractions** - Required, for request context
 - **HoneyDrunk.Auth.AspNetCore** - Optional, for identity context
 - **HoneyDrunk.Transport** - Optional, for envelope mapping
 
@@ -383,7 +387,7 @@ Applications using HoneyDrunk.Web.Rest:
 - [AspNetCore README](../HoneyDrunk.Web.Rest.AspNetCore/README.md) - Middleware documentation
 
 ### Related Projects
-- [HoneyDrunk.Kernel](https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel) - Core Grid primitives (optional integration)
+- [HoneyDrunk.Kernel](https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel) - Required Core Grid primitives
 - [HoneyDrunk.Auth](https://github.com/HoneyDrunkStudios/HoneyDrunk.Auth) - Authentication and authorization (optional integration)
 - [HoneyDrunk.Transport](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport) - Messaging infrastructure (optional integration)
 - [HoneyDrunk.Data](https://github.com/HoneyDrunkStudios/HoneyDrunk.Data) - Persistence conventions

--- a/HoneyDrunk.Web.Rest/docs/Middleware.md
+++ b/HoneyDrunk.Web.Rest/docs/Middleware.md
@@ -55,24 +55,23 @@ public sealed class CorrelationMiddleware
 
 ### Purpose
 
-Extracts correlation ID from incoming request headers, Kernel operation context, or generates a new one. Stores the ID in `ICorrelationIdAccessor` for use throughout the request lifecycle and optionally adds it to response headers.
+Requires the correlation ID from the live Kernel operation context. Stores the ID in `ICorrelationIdAccessor` for use throughout the request lifecycle and optionally adds it to response headers.
 
 ### Behavior
 
-1. **Check Kernel context** - Uses `IOperationContext.CorrelationId` if `IOperationContextAccessor` is registered
-2. **Check incoming header** - Looks for `X-Correlation-Id` (configurable)
-3. **Compare sources** - If both Kernel and header values are present and differ, logs a warning with both values, HTTP method, and request path
-4. **Generate if missing** - Uses `Activity.Current?.Id` if available, otherwise creates a new GUID
+1. **Require Kernel context** - Uses `IOperationContext.CorrelationId` from the live Kernel request context
+2. **Check incoming header** - Looks for `X-Correlation-Id` (configurable) only to detect mismatches
+3. **Compare sources** - If Kernel and header values differ, logs a warning with both values, HTTP method, and request path
+4. **Fail fast if missing** - Throws when Kernel context or its correlation ID is absent
 5. **Store in accessor** - Makes ID available via `ICorrelationIdAccessor`
 6. **Store in HttpContext.Items** - Uses `HeaderNames.CorrelationId` constant
 7. **Add to response header** - Returns correlation ID to caller
 
 ### Correlation ID Priority (highest to lowest)
 
-1. **Kernel `IOperationContext.CorrelationId`** - If `IOperationContextAccessor` is registered and has a current context
-2. **Incoming `X-Correlation-Id` header** - From the request
-3. **`Activity.Current?.Id`** - If available (from distributed tracing)
-4. **Generated GUID** - If `GenerateCorrelationIdIfMissing = true`
+1. **Kernel `IOperationContext.CorrelationId`** - From the live Kernel request context
+2. **Incoming `X-Correlation-Id` header** - Compared for mismatch warnings only
+3. **Missing Kernel context** - Fails fast instead of fabricating request correlation
 
 ### Configuration
 
@@ -80,7 +79,7 @@ Extracts correlation ID from incoming request headers, Kernel operation context,
 services.AddRest(options =>
 {
     options.CorrelationIdHeaderName = "X-Correlation-Id";     // Header name
-    options.GenerateCorrelationIdIfMissing = true;            // Auto-generate
+    options.GenerateCorrelationIdIfMissing = true;            // Legacy option; Kernel supplies correlation
     options.ReturnCorrelationIdInResponseHeader = true;       // Echo back
 });
 ```
@@ -118,10 +117,10 @@ Request:
     │
     ▼
 CorrelationMiddleware:
-  - Checks IOperationContextAccessor (if registered)
-  - Falls back to extracting "client-abc-123" from header
-  - Sets ICorrelationIdAccessor.CorrelationId = "client-abc-123"
-  - Sets HttpContext.Items[HeaderNames.CorrelationId] = "client-abc-123"
+  - Requires IOperationContextAccessor.Current.CorrelationId
+  - Logs a mismatch if the incoming header differs
+  - Sets ICorrelationIdAccessor.CorrelationId to the Kernel correlation ID
+  - Sets HttpContext.Items[HeaderNames.CorrelationId] to the Kernel correlation ID
   - Registers response callback to add header
     │
     ▼
@@ -289,7 +288,7 @@ Enriches the logging scope with correlation ID, request metadata, and Kernel con
 1. **Create logging scope** - Adds properties to scope
 2. **Include correlation ID** - From `ICorrelationIdAccessor`
 3. **Include request metadata** - HTTP method, path, request ID, trace ID
-4. **Include Kernel context** - If `IOperationContextAccessor` is registered:
+4. **Include Kernel context** - From the live Kernel request context:
    - OperationId, OperationName, CausationId
    - TenantId, ProjectId
    - NodeId, StudioId, Environment (from IGridContext)


### PR DESCRIPTION
## Summary
- Require Kernel request context before Web.Rest registration and during correlation middleware execution.
- Stop silently falling back to request headers/generated correlation IDs when Kernel context is missing.
- Consolidate duplicated `ApiResult` / `ApiResult<T>` failure factory construction while preserving public APIs.
- Bump Web.Rest packages to `0.5.0` and align Core dependencies with current Kernel/Auth/Transport/Vault package versions.

## Validation
- `dotnet restore HoneyDrunk.Web.Rest\\HoneyDrunk.Web.Rest.slnx --ignore-failed-sources`
- `dotnet build HoneyDrunk.Web.Rest\\HoneyDrunk.Web.Rest.slnx --no-restore`
- `dotnet test HoneyDrunk.Web.Rest\\HoneyDrunk.Web.Rest.slnx --no-build --verbosity minimal`
- `git diff --check`

## Notes
- Restore/build still emit the known Azure Artifacts `NU1900` vulnerability metadata warning because that feed is inaccessible locally.
- Release hygiene checked before version bump: `v0.4.0` tag exists locally/remotely and Web.Rest packages exist on NuGet at `0.4.0`.

Closes #17
Closes #15
