### PR TITLE
chore: seed Web.Rest coverage baseline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: PR
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -10,6 +12,7 @@ permissions:
 jobs:
   pr-core:
     name: PR Core
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       checks: write
@@ -24,7 +27,26 @@ jobs:
       project-path: './HoneyDrunk.Web.Rest.slnx'
       enable-secret-scan: true
       enable-accessibility-check: false
+      patch-coverage-threshold: 75
+      absolute-coverage-floor: 70
       post-pr-summary: true
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage-baseline-ratchet:
+    name: Coverage Baseline Ratchet
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+      checks: write
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/coverage-baseline-ratchet.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      configuration: 'Release'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Web.Rest'
+      project-path: './HoneyDrunk.Web.Rest.slnx'
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ _TeamCity*
 
 # Coverlet is a free, cross platform Code Coverage Tool
 coverage*.json
+!**/.github/coverage-baseline.json
 coverage*.xml
 coverage*.info
 

--- a/HoneyDrunk.Web.Rest/.github/coverage-baseline.json
+++ b/HoneyDrunk.Web.Rest/.github/coverage-baseline.json
@@ -1,0 +1,5 @@
+{
+  "totalLineCoverage": 87.8,
+  "commit": "pending-merge",
+  "measuredAtUtc": "2026-05-19T17:27:59Z"
+}

--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Internal
+
+- Seeded Web.Rest coverage baseline above the Grid PR coverage gate floor and wired the coverage baseline ratchet artifact.
+- Added focused Web.Rest helper coverage and kept canary tests from emitting separate coverage artifacts that can understate unit coverage in the PR gate.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/CoverageGateBackfillTests.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/CoverageGateBackfillTests.cs
@@ -1,0 +1,251 @@
+#pragma warning disable SA1600 // Test names are descriptive enough for focused coverage backfill.
+
+using HoneyDrunk.Web.Rest.Abstractions.Constants;
+using HoneyDrunk.Web.Rest.Abstractions.Errors;
+using HoneyDrunk.Web.Rest.Abstractions.Results;
+using HoneyDrunk.Web.Rest.AspNetCore.Auth;
+using HoneyDrunk.Web.Rest.AspNetCore.Context;
+using HoneyDrunk.Web.Rest.AspNetCore.Errors;
+using HoneyDrunk.Web.Rest.AspNetCore.MinimalApi;
+using HoneyDrunk.Web.Rest.AspNetCore.Mvc;
+using HoneyDrunk.Web.Rest.AspNetCore.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+
+namespace HoneyDrunk.Web.Rest.Tests.AspNetCore;
+
+/// <summary>
+/// Focused coverage for low-risk REST helper surface that shapes public responses and endpoint metadata.
+/// </summary>
+public sealed class CoverageGateBackfillTests
+{
+    public static TheoryData<HttpStatusCode, string> StatusCodeMappings => new()
+    {
+        { HttpStatusCode.BadRequest, ApiErrorCode.BadRequest },
+        { HttpStatusCode.Unauthorized, ApiErrorCode.Unauthorized },
+        { HttpStatusCode.Forbidden, ApiErrorCode.Forbidden },
+        { HttpStatusCode.NotFound, ApiErrorCode.NotFound },
+        { HttpStatusCode.Conflict, ApiErrorCode.Conflict },
+        { HttpStatusCode.NotImplemented, ApiErrorCode.NotImplemented },
+        { HttpStatusCode.ServiceUnavailable, ApiErrorCode.ServiceUnavailable },
+        { HttpStatusCode.GatewayTimeout, ApiErrorCode.InternalError },
+    };
+
+    [Theory]
+    [MemberData(nameof(StatusCodeMappings))]
+    public void DefaultExceptionMappings_MapStatusCodesToStableErrorCodes(HttpStatusCode statusCode, string expected)
+    {
+        DefaultExceptionMappings.StatusCodeToErrorCode(statusCode).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void DefaultExceptionMappings_CreateExpectedErrorResponses()
+    {
+        DefaultExceptionMappings.BadRequest("corr", "bad", "trace").Error.Code.ShouldBe(ApiErrorCode.BadRequest);
+        DefaultExceptionMappings.NotFound("corr").Error.Code.ShouldBe(ApiErrorCode.NotFound);
+        DefaultExceptionMappings.Unauthorized("corr").Error.Message.ShouldBe("Authentication is required.");
+        DefaultExceptionMappings.Forbidden("corr", "nope").Error.Message.ShouldBe("nope");
+        DefaultExceptionMappings.Conflict("corr", "conflict").Error.Code.ShouldBe(ApiErrorCode.Conflict);
+        DefaultExceptionMappings.InternalError("corr").Error.Code.ShouldBe(ApiErrorCode.InternalError);
+    }
+
+    [Fact]
+    public void ApiConventions_ReturnStandardResultTypesAndPayloads()
+    {
+        OkObjectResult ok = ApiConventions.Ok("value", "corr").ShouldBeOfType<OkObjectResult>();
+        ok.Value.ShouldBeOfType<ApiResult<string>>().Data.ShouldBe("value");
+
+        CreatedResult created = ApiConventions.Created("/items/1", 123, "corr").ShouldBeOfType<CreatedResult>();
+        created.Location.ShouldBe("/items/1");
+        created.Value.ShouldBeOfType<ApiResult<int>>().Data.ShouldBe(123);
+
+        ApiConventions.NoContent().ShouldBeOfType<NoContentResult>();
+        ApiConventions.BadRequest("corr", "bad").ShouldBeOfType<BadRequestObjectResult>().Value.ShouldBeOfType<ApiErrorResponse>().Error.Code.ShouldBe(ApiErrorCode.BadRequest);
+        ApiConventions.NotFound("corr").ShouldBeOfType<NotFoundObjectResult>().Value.ShouldBeOfType<ApiErrorResponse>().Error.Code.ShouldBe(ApiErrorCode.NotFound);
+        ApiConventions.Unauthorized("corr").ShouldBeOfType<UnauthorizedObjectResult>().Value.ShouldBeOfType<ApiErrorResponse>().Error.Code.ShouldBe(ApiErrorCode.Unauthorized);
+        ApiConventions.Conflict("corr", "conflict").ShouldBeOfType<ConflictObjectResult>().Value.ShouldBeOfType<ApiErrorResponse>().Error.Code.ShouldBe(ApiErrorCode.Conflict);
+
+        ObjectResult forbidden = ApiConventions.Forbidden("corr").ShouldBeOfType<ObjectResult>();
+        forbidden.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+        forbidden.Value.ShouldBeOfType<ApiErrorResponse>().Error.Code.ShouldBe(ApiErrorCode.Forbidden);
+
+        ObjectResult internalError = ApiConventions.InternalError("corr").ShouldBeOfType<ObjectResult>();
+        internalError.StatusCode.ShouldBe(StatusCodes.Status500InternalServerError);
+        internalError.Value.ShouldBeOfType<ApiErrorResponse>().Error.Code.ShouldBe(ApiErrorCode.InternalError);
+    }
+
+    [Fact]
+    public void ModelStateValidationFilter_LeavesValidModelStateUntouched()
+    {
+        ActionExecutingContext context = CreateActionExecutingContext(new ServiceCollection().BuildServiceProvider());
+
+        new ModelStateValidationFilter().OnActionExecuting(context);
+
+        context.Result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ModelStateValidationFilter_ShapesInvalidModelStateWithAccessorCorrelationId()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<ICorrelationIdAccessor>(new TestCorrelationIdAccessor("from-accessor"));
+        ActionExecutingContext context = CreateActionExecutingContext(services.BuildServiceProvider());
+        context.ModelState.AddModelError("name", "Name is required.");
+
+        new ModelStateValidationFilter().OnActionExecuting(context);
+
+        BadRequestObjectResult result = context.Result.ShouldBeOfType<BadRequestObjectResult>();
+        ApiErrorResponse response = result.Value.ShouldBeOfType<ApiErrorResponse>();
+        response.CorrelationId.ShouldBe("from-accessor");
+        response.Error.Code.ShouldBe(ApiErrorCode.ValidationFailed);
+        response.ValidationErrors.ShouldNotBeNull();
+        response.ValidationErrors.ShouldContain(error => error.Field == "name" && error.Message == "Name is required.");
+    }
+
+    [Fact]
+    public void ModelStateValidationFilter_FallsBackToContextItemAndExceptionMessage()
+    {
+        ActionExecutingContext context = CreateActionExecutingContext(new ServiceCollection().BuildServiceProvider());
+        context.HttpContext.Items[HeaderNames.CorrelationId] = "from-items";
+        context.ModelState.AddModelError("age", string.Empty);
+
+        new ModelStateValidationFilter().OnActionExecuting(context);
+
+        ApiErrorResponse response = context.Result.ShouldBeOfType<BadRequestObjectResult>().Value.ShouldBeOfType<ApiErrorResponse>();
+        response.CorrelationId.ShouldBe("from-items");
+        response.ValidationErrors.ShouldNotBeNull();
+        response.ValidationErrors.ShouldContain(error => error.Field == "age" && error.Message == "Invalid value.");
+    }
+
+    [Fact]
+    public async Task RestAuthExtensions_WriteUnauthorizedAndForbiddenResponses()
+    {
+        DefaultHttpContext unauthorized = CreateHttpContext(new TestCorrelationIdAccessor("from-accessor"));
+        await RestAuthExtensions.WriteUnauthorizedResponseAsync(unauthorized, "login");
+
+        unauthorized.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+        unauthorized.Response.ContentType.ShouldBe(MediaTypes.Json);
+        ApiErrorResponse unauthorizedResponse = await ReadResponseAsync(unauthorized);
+        unauthorizedResponse.CorrelationId.ShouldBe("from-accessor");
+        unauthorizedResponse.Error.Code.ShouldBe(ApiErrorCode.Unauthorized);
+        unauthorizedResponse.Error.Message.ShouldBe("login");
+
+        DefaultHttpContext forbidden = CreateHttpContext();
+        forbidden.Request.Headers[HeaderNames.CorrelationId] = "from-header";
+        await RestAuthExtensions.WriteForbiddenResponseAsync(forbidden);
+
+        forbidden.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+        ApiErrorResponse forbiddenResponse = await ReadResponseAsync(forbidden);
+        forbiddenResponse.CorrelationId.ShouldBe("from-header");
+        forbiddenResponse.Error.Code.ShouldBe(ApiErrorCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task RestAuthExtensions_DoNotWriteAfterResponseHasStarted()
+    {
+        DefaultHttpContext context = CreateHttpContext();
+        context.Features.Set<IHttpResponseFeature>(new StartedResponseFeature());
+
+        await RestAuthExtensions.WriteUnauthorizedResponseAsync(context);
+        await RestAuthExtensions.WriteForbiddenResponseAsync(context);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        context.Response.Body.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RestEndpointConventions_AddExpectedMetadataAndReturnSameBuilder()
+    {
+        WebApplicationBuilder appBuilder = WebApplication.CreateBuilder();
+        using WebApplication app = appBuilder.Build();
+
+        RouteHandlerBuilder standard = app.MapPost("/standard", () => Results.Ok());
+        standard.WithRest().ShouldBeSameAs(standard);
+        standard.WithRest<string>().ShouldBeSameAs(standard);
+        standard.WithRestCreate<string>().ShouldBeSameAs(standard);
+        standard.WithRestDelete().ShouldBeSameAs(standard);
+        standard.RequireRestAuth().ShouldBeSameAs(standard);
+        standard.RequireRestAuth("named-policy").ShouldBeSameAs(standard);
+
+        standard.WithRestDelete().ShouldBeSameAs(standard);
+    }
+
+    [Fact]
+    public void RestEndpointConventions_RejectNullBuilders()
+    {
+        RouteHandlerBuilder builder = null!;
+
+        Should.Throw<ArgumentNullException>(() => builder.WithRest());
+        Should.Throw<ArgumentNullException>(() => builder.WithRest<string>());
+        Should.Throw<ArgumentNullException>(() => builder.WithRestCreate<string>());
+        Should.Throw<ArgumentNullException>(() => builder.WithRestDelete());
+        Should.Throw<ArgumentNullException>(() => builder.RequireRestAuth());
+    }
+
+    private static ActionExecutingContext CreateActionExecutingContext(IServiceProvider services)
+    {
+        DefaultHttpContext httpContext = new() { RequestServices = services };
+        ActionContext actionContext = new(httpContext, new RouteData(), new ActionDescriptor(), new ModelStateDictionary());
+        return new ActionExecutingContext(actionContext, [], new Dictionary<string, object?>(), controller: new object());
+    }
+
+    private static DefaultHttpContext CreateHttpContext(ICorrelationIdAccessor? accessor = null)
+    {
+        ServiceCollection services = new();
+        if (accessor is not null)
+        {
+            services.AddSingleton(accessor);
+        }
+
+        DefaultHttpContext context = new() { RequestServices = services.BuildServiceProvider() };
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task<ApiErrorResponse> ReadResponseAsync(DefaultHttpContext context)
+    {
+        context.Response.Body.Position = 0;
+        return (await JsonSerializer.DeserializeAsync<ApiErrorResponse>(context.Response.Body, JsonOptionsDefaults.SerializerOptions))!;
+    }
+
+    private sealed class StartedResponseFeature : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+
+        public string? ReasonPhrase { get; set; }
+
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+
+        public Stream Body { get; set; } = new MemoryStream();
+
+        public bool HasStarted => true;
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+        }
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+        }
+    }
+
+    private sealed class TestCorrelationIdAccessor(string? correlationId) : ICorrelationIdAccessor
+    {
+        public string? CorrelationId { get; private set; } = correlationId;
+
+        public void SetCorrelationId(string correlationId)
+        {
+            CorrelationId = correlationId;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Raises Web.Rest unit coverage above the Grid PR coverage floor and seeds `HoneyDrunk.Web.Rest/.github/coverage-baseline.json` at the locally measured total line coverage.
- Splits PR validation from the default-branch coverage ratchet: PRs run read-only `pr-core`; pushes to `main` run the write-scoped ratchet workflow.
- Adds focused tests for REST helper/metadata/error-shaping surface and keeps canary tests from emitting a separate low-signal coverage artifact.
- Adds the repo-level Unreleased/Internal changelog note.

## Coverage
- Initial measured merged total line coverage: **72.6%** (`555/764` lines), but the GitHub gate reads the Cobertura artifact used by PR validation and reported **66.7%**.
- Final local PR-gate coverage artifact: **87.8%** (`671/764` lines).
- Final merged ReportGenerator total: **87.8%**.
- Branch coverage: **75.4%**.

## Validation
- `dotnet test HoneyDrunk.Web.Rest\HoneyDrunk.Web.Rest.slnx --collect:"XPlat Code Coverage" --results-directory coverage-raw` + `reportgenerator -reporttypes:"JsonSummary"` — **87.8%** total line coverage.
- `dotnet test HoneyDrunk.Web.Rest\HoneyDrunk.Web.Rest.slnx --no-restore` — **236 passed**.
- `dotnet format HoneyDrunk.Web.Rest\HoneyDrunk.Web.Rest.slnx --verify-no-changes --no-restore` — passed.
- Workflow YAML parse — passed.
- `git diff --check` — passed.

Notes: local restore/test still emits existing `NU1900` warnings because the private Azure Artifacts vulnerability feed cannot be reached from this machine; tests and coverage complete successfully.

Fixes #12
