### PR TITLE
test: align Web.Rest with ADR-0047 test stack

### DIFF
--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Adopted HoneyDrunk.Standards.Tests 0.2.9 for Web.Rest tests/canaries and refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing alignment.
 - Seeded Web.Rest coverage baseline above the Grid PR coverage gate floor and wired the coverage baseline ratchet artifact.
 - Added focused Web.Rest helper coverage and kept canary tests from emitting separate coverage artifacts that can understate unit coverage in the PR gate.
 

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Web.Rest.Abstractions will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Web.Rest.AspNetCore will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="HoneyDrunk.Auth.AspNetCore" Version="0.4.0" />
 
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj
@@ -11,18 +11,13 @@
 
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/CorrelationIdAccessorTests.cs
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/AspNetCore/CorrelationIdAccessorTests.cs
@@ -77,29 +77,37 @@ public sealed class CorrelationIdAccessorTests
         CorrelationIdAccessor accessor1 = new();
         CorrelationIdAccessor accessor2 = new();
 
-        string? capturedId1 = null;
-        string? capturedId2 = null;
+        TaskCompletionSource bothContextsSet = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int contextsSet = 0;
 
-        Task task1 = Task.Run(() =>
+        Task<string?> task1 = Task.Run(async () =>
         {
             accessor1.SetCorrelationId("context-1-id");
-            Thread.Sleep(50); // Ensure overlap
-            capturedId1 = accessor1.CorrelationId;
+            SignalContextSet();
+            await bothContextsSet.Task;
+            return accessor1.CorrelationId;
         });
 
-        Task task2 = Task.Run(() =>
+        Task<string?> task2 = Task.Run(async () =>
         {
             accessor2.SetCorrelationId("context-2-id");
-            Thread.Sleep(50); // Ensure overlap
-            capturedId2 = accessor2.CorrelationId;
+            SignalContextSet();
+            await bothContextsSet.Task;
+            return accessor2.CorrelationId;
         });
 
-        await Task.WhenAll(task1, task2);
+        string?[] capturedIds = await Task.WhenAll(task1, task2);
 
-        // Note: Since CorrelationIdAccessor uses static AsyncLocal, the values
-        // may affect each other. This test verifies the behavior.
-        // In production, each request gets its own correlation ID set at the start.
-        (capturedId1 ?? capturedId2).ShouldNotBeNullOrWhiteSpace();
+        capturedIds[0].ShouldBe("context-1-id");
+        capturedIds[1].ShouldBe("context-2-id");
+
+        void SignalContextSet()
+        {
+            if (Interlocked.Increment(ref contextsSet) == 2)
+            {
+                bothContextsSet.SetResult();
+            }
+        }
     }
 
     /// <summary>

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Tests/HoneyDrunk.Web.Rest.Tests.csproj
@@ -10,22 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- adopt `HoneyDrunk.Standards.Tests` 0.2.9 in Web.Rest tests and canaries, removing direct xUnit/test-sdk/coverlet references
- refresh `HoneyDrunk.Standards` references from 0.2.7 to 0.2.9 across Web.Rest projects
- replace test `Thread.Sleep` calls with async delay so the suite passes the ADR-0047 analyzer rules
- document the ADR-0047 testing alignment in repo/package changelogs

## Validation

- `git diff --check`
- `dotnet restore HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx --source https://api.nuget.org/v3/index.json`
- `dotnet test HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx -c Release --no-restore`
  - `HoneyDrunk.Web.Rest.Tests`: 209 passed
- `dotnet test HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Canary/HoneyDrunk.Web.Rest.Canary.csproj -c Release --no-restore`
  - `HoneyDrunk.Web.Rest.Canary`: 27 passed

## ADR / Issues

Contributes to HoneyDrunk.Architecture#188 and HoneyDrunk.Architecture#189.