### PR TITLE
ci(adr-0044): enable grid review requests

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,23 @@
+name: Grid Review Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  request-grid-review:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main
+    with:
+      openclaw-webhook-url: ${{ vars.OPENCLAW_GRID_REVIEW_WEBHOOK_URL || '' }}
+      review-config-path: .honeydrunk-review.yaml
+      upload-fallback-artifact: true
+      post-fallback-comment: false
+      artifact-name: grid-review-request
+    secrets:
+      openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  issues: write
 
 jobs:
   request-grid-review:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 jobs:
   request-grid-review:
@@ -20,3 +21,4 @@ jobs:
     secrets:
       openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,6 @@ jobs:
     permissions:
       contents: write
       checks: write
-      issues: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/coverage-baseline-ratchet.yml@main
     with:
       dotnet-version: '10.0.x'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      issues: write
       pull-requests: write
       security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
@@ -40,6 +41,7 @@ jobs:
     permissions:
       contents: write
       checks: write
+      issues: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/coverage-baseline-ratchet.yml@main
     with:
       dotnet-version: '10.0.x'

--- a/.honeydrunk-review.yaml
+++ b/.honeydrunk-review.yaml
@@ -1,0 +1,8 @@
+enabled: true
+runner: openclaw-codex
+severity_floor: Suggest
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00

--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Adopted HoneyDrunk.Standards.Tests 0.2.9 for Web.Rest tests/canaries and refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing alignment.
 - Seeded Web.Rest coverage baseline above the Grid PR coverage gate floor and wired the coverage baseline ratchet artifact.
 - Added focused Web.Rest helper coverage and kept canary tests from emitting separate coverage artifacts that can understate unit coverage in the PR gate.
@@ -23,8 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - `AddRest()` now requires Kernel request context services from `AddHoneyDrunkNode()` before Web.Rest is registered.
 - `CorrelationMiddleware` now requires a live Kernel `IOperationContext` and uses its `CorrelationId`; it no longer falls back to request headers or generated IDs without Kernel context.
 - Consolidated duplicated `ApiResult` / `ApiResult<T>` failure factory construction while preserving public factory APIs and response shape.
@@ -34,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Updated `HoneyDrunk.Kernel.Abstractions` from 0.4.0 to 0.5.0 for typed `TenantId` context adoption.
 - Updated `HoneyDrunk.Transport` from 0.4.0 to 0.5.0.
 - `RequestLoggingScopeMiddleware` now omits the `TenantId` log-scope property for Internal-tenant requests and emits the sanitized ULID string for non-Internal requests.
@@ -50,8 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Updated `HoneyDrunk.Web.Rest.AspNetCore` to consume the Vault Azure Key Vault, App Configuration, and Event Grid provider packages.
 
 ## [0.2.0] - 2026-02-14
@@ -67,8 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Updated HoneyDrunk.Kernel.Abstractions from 0.3.0 to 0.4.0
 - Updated HoneyDrunk.Transport from 0.3.0 to 0.4.0
 - Updated HoneyDrunk.Auth.AspNetCore from 0.1.0 to 0.2.0

--- a/HoneyDrunk.Web.Rest/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - `AddRest()` now requires Kernel request context services from `AddHoneyDrunkNode()` before Web.Rest is registered.
 - `CorrelationMiddleware` now requires a live Kernel `IOperationContext` and uses its `CorrelationId`; it no longer falls back to request headers or generated IDs without Kernel context.
 - Consolidated duplicated `ApiResult` / `ApiResult<T>` failure factory construction while preserving public factory APIs and response shape.
@@ -32,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Updated `HoneyDrunk.Kernel.Abstractions` from 0.4.0 to 0.5.0 for typed `TenantId` context adoption.
 - Updated `HoneyDrunk.Transport` from 0.4.0 to 0.5.0.
 - `RequestLoggingScopeMiddleware` now omits the `TenantId` log-scope property for Internal-tenant requests and emits the sanitized ULID string for non-Internal requests.
@@ -46,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Updated `HoneyDrunk.Web.Rest.AspNetCore` to consume the Vault Azure Key Vault, App Configuration, and Event Grid provider packages.
 
 ## [0.2.0] - 2026-02-14
@@ -61,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Updated HoneyDrunk.Kernel.Abstractions from 0.3.0 to 0.4.0
 - Updated HoneyDrunk.Transport from 0.3.0 to 0.4.0
 - Updated HoneyDrunk.Auth.AspNetCore from 0.1.0 to 0.2.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
@@ -9,22 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
 
 ## [0.5.0] - 2026-05-18
 
 ### Changed
 
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Consolidated `ApiResult` and `ApiResult<T>` failure factory construction while preserving public factory method signatures and serialized response contracts.
 
 ## [0.4.0] - 2026-05-04
 
 ### Changed
 
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.4.0
 - No API surface changes
 
@@ -32,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.3.0
 - No API surface changes
 
@@ -40,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.2.0
 - No API surface changes
 

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md
@@ -9,28 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
 
 ## [0.5.0] - 2026-05-18
 
 ### Changed
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Consolidated `ApiResult` and `ApiResult<T>` failure factory construction while preserving public factory method signatures and serialized response contracts.
 
 ## [0.4.0] - 2026-05-04
 
 ### Changed
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.4.0
 - No API surface changes
 
 ## [0.3.0] - 2026-04-25
 
 ### Changed
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.3.0
 - No API surface changes
 
 ## [0.2.0] - 2026-02-14
 
 ### Changed
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Version alignment with HoneyDrunk.Web.Rest.AspNetCore 0.2.0
 - No API surface changes
 

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -9,16 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
 
 ## [0.5.0] - 2026-05-18
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 #### Middleware
 - `CorrelationMiddleware` now requires a live Kernel `IOperationContext` for each request and uses `IOperationContext.CorrelationId` as the only correlation source.
 - Incoming correlation headers are still compared to Kernel context for mismatch warnings, but Web.Rest no longer falls back to headers or generated IDs when Kernel context is missing.
@@ -37,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 #### Middleware
 - `RequestLoggingScopeMiddleware` now reads Kernel's typed `TenantId` and omits the `TenantId` log-scope property for Internal-tenant requests.
 - Non-Internal tenant requests continue to emit `TenantId` as the sanitized ULID string.
@@ -65,8 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 #### Dependencies
 - Bumped `HoneyDrunk.Kernel.Abstractions` from 0.3.0 to 0.4.0
 - Bumped `HoneyDrunk.Transport` from 0.3.0 to 0.4.0

--- a/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
+++ b/HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 - Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
 
 ## [0.5.0] - 2026-05-18
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 #### Middleware
 - `CorrelationMiddleware` now requires a live Kernel `IOperationContext` for each request and uses `IOperationContext.CorrelationId` as the only correlation source.
 - Incoming correlation headers are still compared to Kernel context for mismatch warnings, but Web.Rest no longer falls back to headers or generated IDs when Kernel context is missing.
@@ -33,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 #### Middleware
 - `RequestLoggingScopeMiddleware` now reads Kernel's typed `TenantId` and omits the `TenantId` log-scope property for Internal-tenant requests.
 - Non-Internal tenant requests continue to emit `TenantId` as the sanitized ULID string.
@@ -59,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for repository PRs.
 #### Dependencies
 - Bumped `HoneyDrunk.Kernel.Abstractions` from 0.3.0 to 0.4.0
 - Bumped `HoneyDrunk.Transport` from 0.3.0 to 0.4.0


### PR DESCRIPTION
## Summary
- Enable ADR-0044 OpenClaw/Codex Grid Review Runner request generation for HoneyDrunk.Web.Rest PRs.
- Add .honeydrunk-review.yaml with advisory review enabled and standard generated-file skip paths.
- Add the pr-review.yml caller for job-review-request.yml, using the org-level OpenClaw webhook secret/variable.
- Grant issues: write to PR Core when needed for managed labels/comments.
- Note the CI tooling change in repository changelogs.

Authorship: agent-codex
Packet: HoneyDrunk.Architecture#182 / generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
Out-of-band reason: N/A

## Verification
- python C:\Users\tatte\.openclaw\workspace\validate-yaml.py .github\workflows\pr-review.yml .honeydrunk-review.yaml
- git diff --check

Size justification: N/A