### PR TITLE
ci: centralize release workflow mechanics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build, Pack & Publish
     needs: prepare
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
       security-events: write
@@ -56,44 +56,15 @@ jobs:
       project-path: 'HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx'
       enable-nuget-publish: true
       nuget-source: 'https://api.nuget.org/v3/index.json'
+      package-version: ${{ needs.prepare.outputs.version }}
+      create-github-release: true
+      github-release-tag: ${{ needs.prepare.outputs.version-tag }}
+      release-product-name: HoneyDrunk.Web.Rest
+      release-product-description: 'Standardized REST API conventions for HoneyDrunk.OS -- unified response envelopes, correlation propagation, exception mapping, and API contracts.'
+      release-nuget-packages: |
+        HoneyDrunk.Web.Rest.Abstractions
+        HoneyDrunk.Web.Rest.AspNetCore
+      release-docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest#readme'
       actions-ref: 'main'
     secrets:
       nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-
-  github-release:
-    name: Create GitHub Release
-    needs: [prepare, release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Checkout Actions
-        uses: actions/checkout@v5
-        with:
-          repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          ref: main
-          path: .actions
-
-      - name: Generate Release Notes
-        id: notes
-        uses: ./.actions/.github/actions/release/generate-notes
-        with:
-          version: ${{ needs.prepare.outputs.version }}
-          product-name: HoneyDrunk.Web.Rest
-          product-description: 'Standardized REST API conventions for HoneyDrunk.OS -- unified response envelopes, correlation propagation, exception mapping, and API contracts.'
-          nuget-packages: |
-            HoneyDrunk.Web.Rest.Abstractions
-            HoneyDrunk.Web.Rest.AspNetCore
-          docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest#readme'
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.prepare.outputs.version-tag }}
-          name: HoneyDrunk.Web.Rest ${{ needs.prepare.outputs.version-tag }}
-          body: ${{ steps.notes.outputs.body }}
-          draft: false
-          prerelease: false


### PR DESCRIPTION
## Summary
- Route GitHub Release creation through the centralized HoneyDrunk.Actions elease.yml workflow.
- Pass the prepared release version/tag and release-note metadata into the reusable workflow.
- Remove repo-local release-note / GitHub Release jobs that duplicated checkout and marketplace-action mechanics.
- Use centralized Function App artifact publishing where this repo builds deployable Function artifacts.

## Testing
- Parsed .github/workflows/*.yml with PyYAML.
- git diff --check
- Searched workflow files for repo-local ctions/checkout, ctions/setup-dotnet, ctions/upload-artifact, and softprops/action-gh-release usage in the standardized release/function paths.

## PR Metadata
Authorship: agent-codex
Packet: N/A
Out-of-band reason: Cross-repo workflow standardization requested after ADR-0012 Node 24 cleanup exposed release workflow drift.
