### PR TITLE
ci: normalize release tag output name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
-      version-tag: ${{ steps.get_version.outputs.version-tag }}
+      version_tag: ${{ steps.get_version.outputs.version_tag }}
     steps:
       - name: Determine version
         id: get_version
@@ -36,7 +36,7 @@ jobs:
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
           fi
           echo "version=$VERSION" >>"$GITHUB_OUTPUT"
-          echo "version-tag=$VERSION_TAG" >>"$GITHUB_OUTPUT"
+          echo "version_tag=$VERSION_TAG" >>"$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
           echo "Publishing tag: $VERSION_TAG"
 
@@ -58,7 +58,7 @@ jobs:
       nuget-source: 'https://api.nuget.org/v3/index.json'
       package-version: ${{ needs.prepare.outputs.version }}
       create-github-release: true
-      github-release-tag: ${{ needs.prepare.outputs.version-tag }}
+      github-release-tag: ${{ needs.prepare.outputs.version_tag }}
       release-product-name: HoneyDrunk.Web.Rest
       release-product-description: 'Standardized REST API conventions for HoneyDrunk.OS -- unified response envelopes, correlation propagation, exception mapping, and API contracts.'
       release-nuget-packages: |


### PR DESCRIPTION
## Summary
- Normalize local release tag workflow outputs to `version_tag` across the standardized publish workflow.
- Keep the centralized reusable workflow input as `github-release-tag`.
- Remove hyphenated local output references so release workflows use one output naming convention.

## Testing
- Parsed `.github/workflows/publish.yml` with PyYAML.
- `git diff --check`
- Verified no stale `version-tag` references remain in the publish workflow.

## PR Metadata
Authorship: agent-codex
Packet: N/A
Out-of-band reason: Follow-up standardization for repos whose release workflow PR merged before output naming was normalized everywhere.